### PR TITLE
Spelling

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -236,6 +236,6 @@ func (c *measuredConn) ReadFrom(r io.Reader) (int64, error) {
 	return n, err
 }
 
-func MeasureConn(conn onet.DuplexConn, bytesSent, bytesRceived *int64) onet.DuplexConn {
-	return &measuredConn{DuplexConn: conn, writeCount: bytesSent, readCount: bytesRceived}
+func MeasureConn(conn onet.DuplexConn, bytesSent, bytesReceived *int64) onet.DuplexConn {
+	return &measuredConn{DuplexConn: conn, writeCount: bytesSent, readCount: bytesReceived}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -93,7 +93,7 @@ func NewShadowsocksMetrics(ipCountryDB *geoip2.Reader) ShadowsocksMetrics {
 			prometheus.CounterOpts{
 				Namespace: "shadowsocks",
 				Name:      "data_bytes",
-				Help:      "Bytes tranferred by the proxy",
+				Help:      "Bytes transferred by the proxy",
 			}, []string{"dir", "proto", "location", "status", "access_key"}),
 		udpAddedNatEntries: prometheus.NewCounter(
 			prometheus.CounterOpts{

--- a/net/net.go
+++ b/net/net.go
@@ -65,7 +65,7 @@ func copyOneWay(leftConn, rightConn DuplexConn) (int64, error) {
 // Relay copies between left and right bidirectionally. Returns number of
 // bytes copied from right to left, from left to right, and any error occurred.
 // Relay allows for half-closed connections: if one side is done writing, it can
-// still read all remaning data from its peer.
+// still read all remaining data from its peer.
 func Relay(leftConn, rightConn DuplexConn) (int64, int64, error) {
 	type res struct {
 		N   int64

--- a/net/net.go
+++ b/net/net.go
@@ -43,7 +43,7 @@ func (dc *duplexConnAdaptor) CloseWrite() error {
 }
 
 // WrapDuplexConn wraps an existing DuplexConn with new Reader and Writer, but
-// preseving the original CloseRead() and CloseWrite().
+// preserving the original CloseRead() and CloseWrite().
 func WrapConn(c DuplexConn, r io.Reader, w io.Writer) DuplexConn {
 	conn := c
 	// We special-case duplexConnAdaptor to avoid multiple levels of nesting.

--- a/shadowsocks/stream_test.go
+++ b/shadowsocks/stream_test.go
@@ -23,7 +23,7 @@ func newTestCipher(t *testing.T) shadowaead.Cipher {
 // Overhead for cipher chacha20poly1305
 const testCipherOverhead = 16
 
-func TestCipherReaderAuthentiationFailure(t *testing.T) {
+func TestCipherReaderAuthenticationFailure(t *testing.T) {
 	cipher := newTestCipher(t)
 
 	clientReader := strings.NewReader("Fails Authentication")

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -32,7 +32,7 @@ import (
 
 const udpBufSize = 64 * 1024
 
-// upack decripts src into dst. It tries each cipher until it finds one that authenticates
+// upack decrypts src into dst. It tries each cipher until it finds one that authenticates
 // correctly. dst and src must not overlap.
 func unpack(dst, src []byte, ciphers map[string]shadowaead.Cipher) ([]byte, string, shadowaead.Cipher, error) {
 	for id, cipher := range ciphers {


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`