### PR TITLE
add GoReleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# goreleaser temporary files.
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+# Copyright 2018 Jigsaw Operations LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build for macOS, Linux, and Windows.
+# Skip 32 bit macOS builds.
+builds:
+  -
+    goos:
+      - darwin
+      - windows
+      - linux
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+archive:
+  replacements:
+    darwin: macos
+    386: i386
+    amd64: x86_64
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/README.md
+++ b/README.md
@@ -116,3 +116,34 @@ For development you may want to use `git clone` over SSH instead of `go get`:
 ```
 git clone git@github.com:Jigsaw-Code/outline-ss-server.git $(go env GOPATH)/src/github.com/Jigsaw-Code/outline-ss-server
 ```
+
+## Release
+
+We use [GoReleaser](https://goreleaser.com/) to build and upload binaries to our [GitHub releases](https://github.com/Jigsaw-Code/outline-ss-server/releases).
+
+Summary:
+- [Install GoReleaser](https://goreleaser.com/install/).
+- Export an environment variable named `GITHUB_TOKEN` with a repo-scoped GitHub token ([create one here](https://github.com/settings/tokens/new)):
+  ```bash
+  export GITHUB_TOKEN=yournewtoken
+  ```
+- `cd` to your clone, most likely:
+  ```bash
+  cd ~/go/src/github.com/Jigsaw-Code/outline-ss-server
+  ```
+- Create a new tag and push it to GitHub e.g.:
+  ```bash
+  git tag v1.0.0
+  git push origin v1.0.0
+  ```
+- Build and upload:
+  ```bash
+  goreleaser
+  ```
+
+To test locally without tagging/uploading , use `--skip-publish`:
+```bash
+goreleaser --skip-publish
+```
+
+Full instructions in [GoReleaser's Quick Start](https://goreleaser.com/quick-start) (jump to the section starting "You’ll need to export a GITHUB_TOKEN environment variable").


### PR DESCRIPTION
Simple config that generates binaries for Linux, Windows, and macOS.

To run, follow the instructions here, jumping to the section starting "You’ll need to export a `GITHUB_TOKEN` environment variable":
https://goreleaser.com/quick-start/

Next step would be to integrate with Travis, as described here:
https://goreleaser.com/ci/