### PR TITLE
Optimize findAccessKey

### DIFF
--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -30,6 +30,8 @@ import (
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 )
 
+// Reads bytes from reader and appends to buf to ensure the needed number of bytes.
+// The cpacity of buf must be at least bytesNeeded.
 func ensureBytes(reader io.Reader, buf []byte, bytesNeeded int) ([]byte, error) {
 	if cap(buf) < bytesNeeded {
 		return buf, io.ErrShortBuffer

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -36,7 +36,7 @@ func BenchmarkTCPFindCipher(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	testPayload := sstest.MakeTestPayload(60)
+	testPayload := sstest.MakeTestPayload(50)
 	for n := 0; n < b.N; n++ {
 		go func() {
 			conn, err := net.Dial("tcp", listener.Addr().String())

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -28,7 +28,7 @@ func BenchmarkUDPUnpack(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	testPayload := sstest.MakeTestPayload(60)
+	testPayload := sstest.MakeTestPayload(50)
 	textBuf := make([]byte, udpBufSize)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {


### PR DESCRIPTION
With this change, we spend half the CPU and allocate 1/20 of the memory, with half the number of allocations. Note how TCP and UDP are quite on par after the change.

Before:
```
BenchmarkTCPFindCipher-12    	    1000	   2441318 ns/op	 2026527 B/op	    3013 allocs/op
BenchmarkUDPUnpack-12        	    2000	    919961 ns/op	  125024 B/op	    1701 allocs/op
```

After:
```
BenchmarkTCPFindCipher-12    	    1000	   1353308 ns/op	  125268 B/op	    1705 allocs/op
BenchmarkUDPUnpack-12        	    2000	    890936 ns/op	  125029 B/op	    1701 allocs/op
```

 The optimization required dealing with low level parts of the protocol. I'm happy to explain it in person.