### PR TITLE
Disable CGO

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+project_name: outline-ss-server
+
 # Build for macOS, Linux, and Windows.
 # Skip 32 bit macOS builds.
 builds:
   -
+    env:
+      - CGO_ENABLED=0
     goos:
-      # Disable macOS while the build is broken: https://github.com/golang/go/issues/29170
-      # - darwin
+      - darwin
       - windows
       - linux
     ignore:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Run the iperf3 client tests listed above on port 10002.
 
 You can mix and match the libev and go servers and clients.
 
+## Benchmark
+
+You can benchmark the cipher finding code with
+```
+go test -cpuprofile cpu.prof -memprofile mem.prof -bench . -benchmem -run=^$ github.com/Jigsaw-Code/outline-ss-server/shadowsocks
+```
+
+You can inspect the CPU or memory profiles with `go tool pprof cpu.prof` or `go tool pprof mem.prof`, and then enter `web` on the prompt.
 
 ## Release
 
@@ -114,6 +122,10 @@ We use [GoReleaser](https://goreleaser.com/) to build and upload binaries to our
 
 Summary:
 - [Install GoReleaser](https://goreleaser.com/install/).
+- Test the build locally:
+  ```
+  goreleaser --rm-dist --snapshot
+  ```
 - Export an environment variable named `GITHUB_TOKEN` with a repo-scoped GitHub token ([create one here](https://github.com/settings/tokens/new)):
   ```bash
   export GITHUB_TOKEN=yournewtoken
@@ -127,10 +139,5 @@ Summary:
   ```bash
   goreleaser
   ```
-
-To test locally without tagging/uploading , use `--skip-publish`:
-```bash
-goreleaser --skip-publish
-```
 
 Full instructions in [GoReleaser's Quick Start](https://goreleaser.com/quick-start) (jump to the section starting "You’ll need to export a GITHUB_TOKEN environment variable").

--- a/shadowsocks/cipher_cache.go
+++ b/shadowsocks/cipher_cache.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadowsocks
+
+import (
+	"container/list"
+	"time"
+)
+
+type CipherCache struct {
+	ipCiphers map[string]*list.List
+}
+
+type CachedItem struct {
+	itemsList *list.List
+	element   *list.Element
+}
+
+func (c *CipherCache) GetCiphers(ip string) []*CachedItem {
+	cipherList, ok := c.ipCiphers[ip]
+	if !ok {
+		return []*CachedItem{}
+	}
+	items := make([]*CachedItem, cipherList.Len())
+	pos := 0
+	for el := cipherList.Front(); el != nil; el = el.Next() {
+		items[pos] = &CachedItem{cipherList, el}
+	}
+	return items
+}
+
+type cipherTime struct {
+	CipherID  string
+	Timestamp time.Time
+}
+
+// WARNING
+// TODO: All of this needs a MUTEX!!!!!!!
+// WARNING
+func (cc *CipherCache) AddCipher(ip string, cipherId string) {
+	cipherList, ok := cc.ipCiphers[ip]
+	if !ok {
+		cipherList = list.New()
+		cc.ipCiphers[ip] = cipherList
+	}
+	cipherList.PushFront(cipherTime{CipherID: cipherId, Timestamp: time.Now()})
+}
+
+func (cc *CipherCache) ExpireOlderThan(oldestTime time.Time) {
+	for key, itemList := range cc.ipCiphers {
+		// Remove expired items
+		for item := itemList.Back(); item != nil && item.Value.(*cipherTime).Timestamp.Sub(oldestTime) < 0; item = itemList.Back() {
+			itemList.Remove(item)
+		}
+		if itemList.Len() == 0 {
+			// TODO: Make this not break the loop
+			delete(cc.ipCiphers, key)
+		}
+	}
+}
+
+func (ci *CachedItem) Refresh() {
+	ci.element.Value.(*cipherTime).Timestamp = time.Now()
+	ci.itemsList.MoveToFront(ci.element)
+}
+
+func (ci *CachedItem) CipherId() string {
+	return ci.element.Value.(*cipherTime).CipherID
+}


### PR DESCRIPTION
This allows us to get statically linked binaries and build for macOS on Linux.

```
$ file dist/linux_amd64/outline-ss-server
dist/linux_amd64/outline-ss-server: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```