### PR TITLE
make goreleaser create draft releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,12 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
+release:
+  # This prevents auto-publishing the release. You need to manually publish it.
+  draft: true
+  # Marks the release as not ready for production in case there's a tag indicator (e.g. -rc1)
+  prerelease: auto
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -139,5 +139,6 @@ Summary:
   ```bash
   goreleaser
   ```
+- Go to https://github.com/Jigsaw-Code/outline-ss-server/releases, review and publish the release.
 
 Full instructions in [GoReleaser's Quick Start](https://goreleaser.com/quick-start) (jump to the section starting "You’ll need to export a GITHUB_TOKEN environment variable").


### PR DESCRIPTION
This allows us to manually review the release before publishing it.
I think this is appropriate for now, since we do manual releases anyway.
Let me know if you disagree