### PR TITLE
Enable Linux ARM builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,14 @@ builds:
       - darwin
       - windows
       - linux
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
     ignore:
       - goos: darwin
         goarch: 386


### PR DESCRIPTION
This enables Linux ARM builds:
- armv6
- armv7
- arm64