### PR TITLE
Optimize trial decryption ordering

### DIFF
--- a/shadowsocks/cipher_list.go
+++ b/shadowsocks/cipher_list.go
@@ -16,23 +16,26 @@ package shadowsocks
 
 import (
 	"container/list"
+	"net"
 	"sync"
 
 	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
 )
 
 // CipherEntry holds a Cipher with an identifier.
+// The public fields are constant, but lastAddress is mutable under cipherList.mu.
 type CipherEntry struct {
-	ID     string
-	Cipher shadowaead.Cipher
+	ID          string
+	Cipher      shadowaead.Cipher
+	lastAddress net.IP
 }
 
 // CipherList is a list of CipherEntry elements that allows for thread-safe snapshotting and
 // moving to front.
 type CipherList interface {
 	PushBack(id string, cipher shadowaead.Cipher) *list.Element
-	SafeSnapshot() []*list.Element
-	SafeMoveToFront(e *list.Element)
+	SafeSnapshot(addr net.IP) []*list.Element
+	SafeMoveToFront(e *list.Element, addr net.IP)
 }
 
 type cipherList struct {
@@ -50,20 +53,38 @@ func (cl *cipherList) PushBack(id string, cipher shadowaead.Cipher) *list.Elemen
 	return cl.list.PushBack(&CipherEntry{ID: id, Cipher: cipher})
 }
 
-func (cl *cipherList) SafeSnapshot() []*list.Element {
+func matchesIP(e *list.Element, addr net.IP) bool {
+	c := e.Value.(*CipherEntry)
+	return addr != nil && addr.Equal(c.lastAddress)
+}
+
+func (cl *cipherList) SafeSnapshot(addr net.IP) []*list.Element {
 	cl.mu.RLock()
 	defer cl.mu.RUnlock()
 	cipherArray := make([]*list.Element, cl.list.Len())
 	i := 0
+	// First pass: put all ciphers with matching last known IP at the front.
 	for e := cl.list.Front(); e != nil; e = e.Next() {
-		cipherArray[i] = e
-		i++
+		if matchesIP(e, addr) {
+			cipherArray[i] = e
+			i++
+		}
+	}
+	// Second pass: include all remaining ciphers in recency order.
+	for e := cl.list.Front(); e != nil; e = e.Next() {
+		if !matchesIP(e, addr) {
+			cipherArray[i] = e
+			i++
+		}
 	}
 	return cipherArray
 }
 
-func (cl *cipherList) SafeMoveToFront(e *list.Element) {
+func (cl *cipherList) SafeMoveToFront(e *list.Element, addr net.IP) {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 	cl.list.MoveToFront(e)
+
+	c := e.Value.(*CipherEntry)
+	c.lastAddress = addr
 }

--- a/shadowsocks/cipher_list.go
+++ b/shadowsocks/cipher_list.go
@@ -35,7 +35,7 @@ type CipherEntry struct {
 type CipherList interface {
 	PushBack(id string, cipher shadowaead.Cipher) *list.Element
 	SafeSnapshotForClientIP(clientIP net.IP) []*list.Element
-	MarkUsedByClientIP(e *list.Element, clientIP net.IP)
+	SafeMarkUsedByClientIP(e *list.Element, clientIP net.IP)
 }
 
 type cipherList struct {
@@ -80,7 +80,7 @@ func (cl *cipherList) SafeSnapshotForClientIP(clientIP net.IP) []*list.Element {
 	return cipherArray
 }
 
-func (cl *cipherList) MarkUsedByClientIP(e *list.Element, clientIP net.IP) {
+func (cl *cipherList) SafeMarkUsedByClientIP(e *list.Element, clientIP net.IP) {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 	cl.list.MoveToFront(e)

--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -104,7 +104,7 @@ func findAccessKey(clientConn onet.DuplexConn, cipherList CipherList) (string, o
 			logger.Debugf("TCP: Found cipher %v at index %d", id, ci)
 		}
 		// Move the active cipher to the front, so that the search is quicker next time.
-		cipherList.MarkUsedByClientIP(entry, clientIP)
+		cipherList.SafeMarkUsedByClientIP(entry, clientIP)
 		ssr := NewShadowsocksReader(io.MultiReader(bytes.NewReader(replayBytes), clientConn), cipher)
 		ssw := NewShadowsocksWriter(clientConn, cipher)
 		return id, onet.WrapConn(clientConn, ssr, ssw).(onet.DuplexConn), nil

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -129,7 +129,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 		b.Fatal(err)
 	}
 	cipherEntries := [numCiphers]*CipherEntry{}
-	for cipherNumber, element := range cipherList.SafeSnapshot(nil) {
+	for cipherNumber, element := range cipherList.SafeSnapshotForClientIP(nil) {
 		cipherEntries[cipherNumber] = element.Value.(*CipherEntry)
 	}
 	for n := 0; n < b.N; n++ {

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -51,7 +51,7 @@ func unpack(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, st
 			logger.Debugf("UDP: Found cipher %v at index %d", id, ci)
 		}
 		// Move the active cipher to the front, so that the search is quicker next time.
-		cipherList.MarkUsedByClientIP(entry, clientIP)
+		cipherList.SafeMarkUsedByClientIP(entry, clientIP)
 		return buf, id, cipher, nil
 	}
 	return nil, "", nil, errors.New("could not find valid cipher")

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -35,10 +35,10 @@ const udpBufSize = 64 * 1024
 
 // upack decrypts src into dst. It tries each cipher until it finds one that authenticates
 // correctly. dst and src must not overlap.
-func unpack(dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.Cipher, error) {
+func unpack(sender net.IP, dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.Cipher, error) {
 	// Try each cipher until we find one that authenticates successfully. This assumes that all ciphers are AEAD.
 	// We snapshot the list because it may be modified while we use it.
-	for _, entry := range cipherList.SafeSnapshot() {
+	for i, entry := range cipherList.SafeSnapshot(sender) {
 		id, cipher := entry.Value.(*CipherEntry).ID, entry.Value.(*CipherEntry).Cipher
 		buf, err := shadowaead.Unpack(dst, src, cipher)
 		if err != nil {
@@ -48,10 +48,10 @@ func unpack(dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.
 			continue
 		}
 		if logger.IsEnabledFor(logging.DEBUG) {
-			logger.Debugf("Selected UDP cipher %v", id)
+			logger.Debugf("Selected UDP cipher %v at index %d", id, i)
 		}
 		// Move the active cipher to the front, so that the search is quicker next time.
-		cipherList.SafeMoveToFront(entry)
+		cipherList.SafeMoveToFront(entry, sender)
 		return buf, id, cipher, nil
 	}
 	return nil, "", nil, errors.New("could not find valid cipher")
@@ -121,7 +121,8 @@ func (s *udpService) Start() {
 			defer logger.Debugf("UDP done with %v", clientAddr.String())
 			logger.Debugf("UDP Request from %v with %v bytes", clientAddr, clientProxyBytes)
 			unpackStart := time.Now()
-			buf, keyID, cipher, err := unpack(textBuf, cipherBuf[:clientProxyBytes], *s.ciphers)
+			ip := clientAddr.(*net.IPAddr).IP
+			buf, keyID, cipher, err := unpack(ip, textBuf, cipherBuf[:clientProxyBytes], *s.ciphers)
 			timeToCipher = time.Now().Sub(unpackStart)
 
 			if err != nil {

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -15,12 +15,16 @@
 package shadowsocks
 
 import (
+	"fmt"
+	"net"
 	"testing"
 
 	logging "github.com/op/go-logging"
+	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
 )
 
-func BenchmarkUDPUnpack(b *testing.B) {
+// Simulates receiving invalid UDP packets on a server with 100 ciphers.
+func BenchmarkUDPUnpackFail(b *testing.B) {
 	logging.SetLevel(logging.INFO, "")
 
 	cipherList, err := MakeTestCiphers(100)
@@ -29,8 +33,72 @@ func BenchmarkUDPUnpack(b *testing.B) {
 	}
 	testPayload := MakeTestPayload(50)
 	textBuf := make([]byte, udpBufSize)
+	testIP := net.ParseIP("192.0.2.1")
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		unpack(textBuf, testPayload, cipherList)
+		unpack(testIP, textBuf, testPayload, cipherList)
+	}
+}
+
+// Simulates receiving valid UDP packets from 100 different users, each with
+// their own cipher and IP address.
+func BenchmarkUDPUnpackRepeat(b *testing.B) {
+	logging.SetLevel(logging.INFO, "")
+
+	const numCiphers = 100 // Must be <256
+	cipherList, err := MakeTestCiphers(numCiphers)
+	if err != nil {
+		b.Fatal(err)
+	}
+	testBuf := make([]byte, udpBufSize)
+	packets := [numCiphers][]byte{}
+	ips := [numCiphers]net.IP{}
+	for i, element := range cipherList.SafeSnapshot(nil) {
+		packets[i] = make([]byte, 0, udpBufSize)
+		plaintext := MakeTestPayload(50)
+		packets[i], err = shadowaead.Pack(make([]byte, udpBufSize), plaintext, element.Value.(*CipherEntry).Cipher)
+		if err != nil {
+			b.Error(err)
+		}
+		ips[i] = net.ParseIP(fmt.Sprintf("192.0.2.%d", i))
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		cipherNumber := n % numCiphers
+		ip := ips[cipherNumber]
+		packet := packets[cipherNumber]
+		_, _, _, err := unpack(ip, testBuf, packet, cipherList)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+// Simulates receiving valid UDP packets from 100 different IP addresses,
+// all using the same cipher.
+func BenchmarkUDPUnpackSharedKey(b *testing.B) {
+	logging.SetLevel(logging.INFO, "")
+
+	cipherList, err := MakeTestCiphers(1) // One widely shared key
+	if err != nil {
+		b.Fatal(err)
+	}
+	testBuf := make([]byte, udpBufSize)
+	plaintext := MakeTestPayload(50)
+	cipher := cipherList.SafeSnapshot(nil)[0].Value.(*CipherEntry).Cipher
+	packet, err := shadowaead.Pack(make([]byte, udpBufSize), plaintext, cipher)
+
+	const numIPs = 100 // Must be <256
+	ips := [numIPs]net.IP{}
+	for i := 0; i < numIPs; i++ {
+		ips[i] = net.ParseIP(fmt.Sprintf("192.0.2.%d", i))
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ip := ips[n%numIPs]
+		_, _, _, err := unpack(ip, testBuf, packet, cipherList)
+		if err != nil {
+			b.Error(err)
+		}
 	}
 }

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -15,7 +15,6 @@
 package shadowsocks
 
 import (
-	"fmt"
 	"net"
 	"testing"
 
@@ -60,7 +59,7 @@ func BenchmarkUDPUnpackRepeat(b *testing.B) {
 		if err != nil {
 			b.Error(err)
 		}
-		ips[i] = net.ParseIP(fmt.Sprintf("192.0.2.%d", i))
+		ips[i] = net.IPv4(192, 0, 2, byte(i))
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -91,7 +90,7 @@ func BenchmarkUDPUnpackSharedKey(b *testing.B) {
 	const numIPs = 100 // Must be <256
 	ips := [numIPs]net.IP{}
 	for i := 0; i < numIPs; i++ {
-		ips[i] = net.ParseIP(fmt.Sprintf("192.0.2.%d", i))
+		ips[i] = net.IPv4(192, 0, 2, byte(i))
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -53,7 +53,7 @@ func BenchmarkUDPUnpackRepeat(b *testing.B) {
 	testBuf := make([]byte, udpBufSize)
 	packets := [numCiphers][]byte{}
 	ips := [numCiphers]net.IP{}
-	for i, element := range cipherList.SafeSnapshot(nil) {
+	for i, element := range cipherList.SafeSnapshotForClientIP(nil) {
 		packets[i] = make([]byte, 0, udpBufSize)
 		plaintext := MakeTestPayload(50)
 		packets[i], err = shadowaead.Pack(make([]byte, udpBufSize), plaintext, element.Value.(*CipherEntry).Cipher)
@@ -85,7 +85,7 @@ func BenchmarkUDPUnpackSharedKey(b *testing.B) {
 	}
 	testBuf := make([]byte, udpBufSize)
 	plaintext := MakeTestPayload(50)
-	cipher := cipherList.SafeSnapshot(nil)[0].Value.(*CipherEntry).Cipher
+	cipher := cipherList.SafeSnapshotForClientIP(nil)[0].Value.(*CipherEntry).Cipher
 	packet, err := shadowaead.Pack(make([]byte, udpBufSize), plaintext, cipher)
 
 	const numIPs = 100 // Must be <256


### PR DESCRIPTION
Ciphers last seen from the client's IP are tried first.
This is mostly relevant to servers that have many
users on separate keys, with simultaneous high-throughput
UDP flows.

Benchmark results before this change (using added benchmarks):
```
BenchmarkTCPFindCipherFail-40      	    1000	   1216804 ns/op
BenchmarkTCPFindCipherRepeat-40    	    2000	   1347786 ns/op
BenchmarkUDPUnpackFail-40          	    2000	    988158 ns/op
BenchmarkUDPUnpackRepeat-40        	    3000	   1014964 ns/op
BenchmarkUDPUnpackSharedKey-40     	  200000	     11505 ns/op
```

After this change:
```
BenchmarkTCPFindCipherFail-40      	    1000	   1499293 ns/op
BenchmarkTCPFindCipherRepeat-40    	   20000	     61834 ns/op
BenchmarkUDPUnpackFail-40          	    2000	    993359 ns/op
BenchmarkUDPUnpackRepeat-40        	  100000	     14883 ns/op
BenchmarkUDPUnpackSharedKey-40     	  200000	     10659 ns/op
```
I believe these benchmarks show no significant change in cases where all ciphers
must be tried, but a significant acceleration when each cipher is used
repeatedly by a different client IP address.