### PR TITLE
Shadowsocks dialer

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -53,6 +53,12 @@ func WrapConn(c DuplexConn, r io.Reader, w io.Writer) DuplexConn {
 	return &duplexConnAdaptor{DuplexConn: conn, r: r, w: w}
 }
 
+// PacketConn is a wrapper for net.PacketConn and io.Writer interfaces.
+type PacketConn interface {
+	net.PacketConn
+	io.Writer
+}
+
 func copyOneWay(leftConn, rightConn DuplexConn) (int64, error) {
 	n, err := io.Copy(leftConn, rightConn)
 	// Send FIN to indicate EOF

--- a/shadowsocks/dialer.go
+++ b/shadowsocks/dialer.go
@@ -1,0 +1,156 @@
+package shadowsocks
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+	"github.com/shadowsocks/go-shadowsocks2/core"
+	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
+	"github.com/shadowsocks/go-shadowsocks2/socks"
+)
+
+// Dialer is a dialer for Shadowsocks proxy connections.
+type Dialer interface {
+	// DialTCP connects to `address` over TCP though the Shadowsocks proxy.
+	// `address` has the form `host:port`, where `host` can be a domain name or IP address.
+	DialTCP(address string) (onet.DuplexConn, error)
+	// DialUDP relays UDP packets to/from `address` though the Shadowsocks proxy.
+	// `address` has the form `host:port`, where `host` can be a domain name or IP address.
+	DialUDP(address string) (onet.PacketConn, error)
+}
+
+type ssDialer struct {
+	proxyIP   net.IP
+	proxyPort int
+	cipher    shadowaead.Cipher
+}
+
+// NewDialer creates a Dialer that routes connections to a Shadowsocks proxy.
+func NewDialer(host, password, cipher string, port int) (Dialer, error) {
+	proxyIP, err := net.ResolveIPAddr("ip", host)
+	if err != nil {
+		return nil, errors.New("Failed to resolve proxy address")
+	}
+	aead, err := newAeadCipher(cipher, password)
+	if err != nil {
+		return nil, err
+	}
+	d := ssDialer{proxyIP: net.ParseIP(proxyIP.String()), proxyPort: port, cipher: aead}
+	return &d, nil
+}
+
+func (d *ssDialer) DialTCP(address string) (onet.DuplexConn, error) {
+	proxyAddr := &net.TCPAddr{IP: d.proxyIP, Port: d.proxyPort}
+	conn, err := net.DialTCP("tcp", nil, proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+	ssw := NewShadowsocksWriter(conn, d.cipher)
+	socksTargetAddr := socks.ParseAddr(address)
+	if socksTargetAddr == nil {
+		return nil, errors.New("Invalid target address")
+	}
+	_, err = ssw.Write(socksTargetAddr)
+	if err != nil {
+		conn.Close()
+		return nil, errors.New("Failed to write target address")
+	}
+	ssr := NewShadowsocksReader(conn, d.cipher)
+	return onet.WrapConn(conn, ssr, ssw), nil
+}
+
+// Clients are encouraged to use the `Write` method of onet.PacketConn to leverage the
+// proxy address as the default destination.
+func (d *ssDialer) DialUDP(address string) (onet.PacketConn, error) {
+	proxyAddr := &net.UDPAddr{IP: d.proxyIP, Port: d.proxyPort}
+	pc, err := net.ListenPacket("udp", "")
+	if err != nil {
+		return nil, err
+	}
+	targetHost, targetPortStr, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, errors.New("Invalid target address")
+	}
+	// Ignore the error, it would have failed when spliting the address
+	targetPort, _ := strconv.Atoi(targetPortStr)
+	targetAddr := &packetConnAddr{Host: targetHost, Port: targetPort}
+	conn := packetConn{
+		PacketConn: pc, proxyAddr: proxyAddr, targetAddr: targetAddr, cipher: d.cipher,
+		buf: make([]byte, udpBufSize)}
+	return &conn, nil
+}
+
+type packetConn struct {
+	net.PacketConn
+	proxyAddr  *net.UDPAddr
+	targetAddr net.Addr
+	cipher     shadowaead.Cipher
+	m          sync.Mutex
+	buf        []byte // Write lock
+}
+
+// WriteTo encrypts b and write to addr using the embedded PacketConn.
+func (c *packetConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	socksTargetAddr := socks.ParseAddr(c.targetAddr.String())
+	if socksTargetAddr == nil {
+		return 0, errors.New("Invalid target address")
+	}
+	buf, err := shadowaead.Pack(c.buf, append(socksTargetAddr, b...), c.cipher)
+	if err != nil {
+		return 0, err
+	}
+	_, err = c.PacketConn.WriteTo(buf, addr)
+	return len(b), err
+}
+
+// ReadFrom reads from the embedded PacketConn and decrypts into b.
+func (c *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, _, err := c.PacketConn.ReadFrom(b)
+	if err != nil {
+		return n, c.targetAddr, err
+	}
+	buf, err := shadowaead.Unpack(b[c.cipher.SaltSize():], b[:n], c.cipher)
+	if err != nil {
+		return n, c.targetAddr, err
+	}
+	socksSrcAddr := socks.SplitAddr(buf[:n])
+	copy(b, buf[len(socksSrcAddr):]) // Remove the SOCKS source address
+
+	return len(buf) - len(socksSrcAddr), c.targetAddr, err
+}
+
+// Convenience struct to hold a domain name or IP address host. Used for SOCKS addressing.
+type packetConnAddr struct {
+	net.Addr
+	Host string
+	Port int
+}
+
+func (a *packetConnAddr) String() string {
+	return net.JoinHostPort(a.Host, strconv.FormatInt(int64(a.Port), 10))
+}
+
+func (a *packetConnAddr) Network() string {
+	return "udp"
+}
+
+func (c *packetConn) Write(b []byte) (int, error) {
+	return c.WriteTo(b, c.proxyAddr)
+}
+
+func newAeadCipher(cipher, password string) (shadowaead.Cipher, error) {
+	ssCipher, err := core.PickCipher(cipher, nil, password)
+	if err != nil {
+		return nil, err
+	}
+	aead, ok := ssCipher.(shadowaead.Cipher)
+	if !ok {
+		return nil, errors.New("Only AEAD ciphers supported")
+	}
+	return aead, nil
+}

--- a/shadowsocks/dialer_test.go
+++ b/shadowsocks/dialer_test.go
@@ -1,0 +1,216 @@
+package shadowsocks
+
+import (
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-ss-server/metrics"
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
+	"github.com/shadowsocks/go-shadowsocks2/socks"
+)
+
+const (
+	testCipher   = "chacha20-ietf-poly1305"
+	testPassword = "testPassword"
+	testPayload  = "!!!test~payload!!!"
+)
+
+func TestShadowsocksDialer_DialTCP(t *testing.T) {
+	listenTCPAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}
+	proxyListener, err := net.ListenTCP("tcp", listenTCPAddr)
+	if err != nil {
+		t.Fatalf("ListenTCP failed: %v", err)
+	}
+	go startShadowsocksTCPProxy(proxyListener, t)
+
+	targetListener, err := net.ListenTCP("tcp", listenTCPAddr)
+	go startTCPEchoServer(targetListener, t)
+
+	proxyHost, proxyPortStr, err := net.SplitHostPort(proxyListener.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to parse proxy address: %v", err)
+	}
+	proxyPort, _ := strconv.Atoi(proxyPortStr)
+	d, err := NewDialer(proxyHost, testPassword, testCipher, proxyPort)
+	if err != nil {
+		t.Fatalf("Failed to create ShadowsocksDialer: %v", err)
+	}
+	conn, err := d.DialTCP(targetListener.Addr().String())
+	if err != nil {
+		t.Fatalf("ShadowsocksDialer.DialTCP failed: %v", err)
+	}
+	_, err = conn.Write([]byte(testPayload))
+	if err != nil {
+		t.Fatalf("Failed to write: %v", err)
+	}
+	buf := make([]byte, len(testPayload))
+	_, err = conn.Read(buf)
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	if string(buf) != testPayload {
+		t.Fatalf("Expected output '%v'. Got '%v'", testPayload, string(buf))
+	}
+}
+
+func TestShadowsocksDialer_DialUDP(t *testing.T) {
+	listenUDPAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}
+	proxyConn, err := net.ListenUDP("udp", listenUDPAddr)
+	if err != nil {
+		t.Fatalf("Proxy ListenUDP failed: %v", err)
+	}
+	go startShadowsocksUDPProxy(proxyConn, t)
+
+	targetConn, err := net.ListenUDP("udp", listenUDPAddr)
+	if err != nil {
+		t.Fatalf("Target ListenUDP failed: %v", err)
+	}
+	go startUDPEchoServer(targetConn, t)
+
+	proxyHost, proxyPortStr, err := net.SplitHostPort(proxyConn.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("Failed to parse proxy address: %v", err)
+	}
+	proxyPort, _ := strconv.Atoi(proxyPortStr)
+	d, err := NewDialer(proxyHost, testPassword, testCipher, proxyPort)
+	if err != nil {
+		t.Fatalf("Failed to create ShadowsocksDialer: %v", err)
+	}
+	conn, err := d.DialUDP(targetConn.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("ShadowsocksDialer.DialUDP failed: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+	_, err = conn.Write([]byte(testPayload))
+	if err != nil {
+		t.Fatalf("Failed to write: %v", err)
+	}
+	buf := make([]byte, udpBufSize)
+	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	if string(buf[:n]) != testPayload {
+		t.Fatalf("Expected output '%v'. Got '%v'", testPayload, string(buf))
+	}
+}
+
+func startShadowsocksTCPProxy(listener *net.TCPListener, t *testing.T) {
+	t.Logf("Starting SS TCP proxy at %v\n", listener.Addr())
+	cipher, err := newAeadCipher(testCipher, testPassword)
+	if err != nil {
+		t.Fatalf("Failed to create cipher: %v", err)
+	}
+	defer listener.Close()
+	for {
+		clientConn, err := listener.AcceptTCP()
+		if err != nil {
+			t.Fatalf("AcceptTCP failed: %v", err)
+		}
+		go func() {
+			ssr := NewShadowsocksReader(clientConn, cipher)
+			ssw := NewShadowsocksWriter(clientConn, cipher)
+			ssClientConn := onet.WrapConn(clientConn, ssr, ssw)
+
+			tgtAddr, err := socks.ReadAddr(ssClientConn)
+			if err != nil {
+				t.Fatalf("Failed to read target address: %v", err)
+			}
+			tgtTCPAddr, err := net.ResolveTCPAddr("tcp", tgtAddr.String())
+			if err != nil {
+				t.Fatalf("Failed to resolve target address: %v", err)
+			}
+			tgtTCPConn, err := net.DialTCP("tcp", nil, tgtTCPAddr)
+			if err != nil {
+				t.Fatalf("Failed to connect to target")
+			}
+			defer tgtTCPConn.Close()
+			tgtTCPConn.SetKeepAlive(true)
+
+			_, _, err = onet.Relay(ssClientConn, tgtTCPConn)
+			if err != nil {
+				t.Fatalf("Failed to relay connection: %v", err)
+			}
+		}()
+	}
+}
+
+func startShadowsocksUDPProxy(conn *net.UDPConn, t *testing.T) {
+	t.Logf("Starting SS UDP proxy at %v\n", conn.LocalAddr())
+	nm := newNATmap(5*time.Second, metrics.NewShadowsocksMetrics(nil))
+	cipherBuf := make([]byte, udpBufSize)
+	clientBuf := make([]byte, udpBufSize)
+	cipher, err := newAeadCipher(testCipher, testPassword)
+	if err != nil {
+		t.Fatalf("Failed to create cipher: %v", err)
+	}
+	defer conn.Close()
+	for {
+		n, clientAddr, err := conn.ReadFromUDP(cipherBuf)
+		if err != nil {
+			t.Fatalf("Failed to read from UDP conn: %v", err)
+		}
+		buf, err := shadowaead.Unpack(clientBuf, cipherBuf[:n], cipher)
+		if err != nil {
+			t.Fatalf("Failed to decrypt: %v", err)
+		}
+		tgtAddr := socks.SplitAddr(buf)
+		if tgtAddr == nil {
+			t.Fatalf("Failed to read target address: %v", err)
+		}
+		tgtUDPAddr, err := net.ResolveUDPAddr("udp", tgtAddr.String())
+		if err != nil {
+			t.Fatalf("Failed to resolve target address: %v", err)
+		}
+		targetConn := nm.Get(clientAddr.String())
+		if targetConn == nil {
+			targetConn, err = net.ListenUDP("udp", nil)
+			if err != nil {
+				t.Fatalf("Failed create UDP socket: %v", err)
+			}
+			nm.Add(clientAddr, conn, cipher, targetConn, "", "")
+		}
+		payload := buf[len(tgtAddr):]
+		_, err = targetConn.WriteTo(payload, tgtUDPAddr)
+		if err != nil {
+			t.Fatalf("Failed to write to target conn: %v", err)
+		}
+	}
+}
+
+func startTCPEchoServer(listener net.Listener, t *testing.T) {
+	t.Logf("Starting TCP echo server at %v\n", listener.Addr())
+	buf := make([]byte, 1024)
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Fatalf("Accept failed: %v", err)
+		}
+		go func() {
+			defer conn.Close()
+			for {
+				n, err := conn.Read(buf)
+				if err != nil {
+					t.Fatalf("Echo server read failed: %v", err)
+				}
+				conn.Write(buf[:n])
+			}
+		}()
+	}
+}
+
+func startUDPEchoServer(conn *net.UDPConn, t *testing.T) {
+	t.Logf("Starting UDP echo server at %v\n", conn.LocalAddr())
+	defer conn.Close()
+	buf := make([]byte, udpBufSize)
+	for {
+		n, addr, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			t.Fatalf("Failed to read from UDP: %v", err)
+		}
+		conn.WriteTo(buf[:n], addr)
+	}
+}

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -121,7 +121,7 @@ func (s *udpService) Start() {
 			defer logger.Debugf("UDP done with %v", clientAddr.String())
 			logger.Debugf("UDP Request from %v with %v bytes", clientAddr, clientProxyBytes)
 			unpackStart := time.Now()
-			ip := clientAddr.(*net.IPAddr).IP
+			ip := clientAddr.(*net.UDPAddr).IP
 			buf, keyID, cipher, err := unpack(ip, textBuf, cipherBuf[:clientProxyBytes], *s.ciphers)
 			timeToCipher = time.Now().Sub(unpackStart)
 
@@ -139,7 +139,7 @@ func (s *udpService) Start() {
 				return onet.NewConnectionError("ERR_RESOLVE_ADDRESS", fmt.Sprintf("Failed to resolve target address %v", tgtAddr.String()), err)
 			}
 			if !tgtUDPAddr.IP.IsGlobalUnicast() {
-				return onet.NewConnectionError("ERR_ADDRESS_INVALID", fmt.Sprintf("Target address is not global unicast: %v", tgtAddr.String()), err)
+				return onet.NewConnectionError("ERR_ADDRESS_INVALID", fmt.Sprintf("Target address is not global unicast: %v", tgtAddr.String()), nil)
 			}
 			if onet.IsPrivateAddress(tgtUDPAddr.IP) {
 				return onet.NewConnectionError("ERR_ADDRESS_PRIVATE", fmt.Sprintf("Target address is a private address: %v", tgtAddr.String()), nil)


### PR DESCRIPTION
* Implements Shadowsocks TCP and UDP client dialers.
* Tests that proxying works through the existing Shadowsocks server implementation.
* Fixes an incorrect address cast in `UDPService`.