### PR TITLE
Probing resistance via timeout

### DIFF
--- a/server.go
+++ b/server.go
@@ -64,6 +64,7 @@ type SSServer struct {
 }
 
 func (s *SSServer) startPort(portNum int) error {
+	timeout := 59 * time.Second
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{Port: portNum})
 	if err != nil {
 		return fmt.Errorf("Failed to start TCP on port %v: %v", portNum, err)
@@ -75,7 +76,7 @@ func (s *SSServer) startPort(portNum int) error {
 	logger.Infof("Listening TCP and UDP on port %v", portNum)
 	port := &SSPort{cipherList: shadowsocks.NewCipherList()}
 	// TODO: Register initial data metrics at zero.
-	port.tcpService = shadowsocks.NewTCPService(listener, &port.cipherList, s.m)
+	port.tcpService = shadowsocks.NewTCPService(listener, &port.cipherList, s.m, timeout)
 	port.udpService = shadowsocks.NewUDPService(packetConn, s.natTimeout, &port.cipherList, s.m)
 	s.ports[portNum] = port
 	go port.udpService.Start()

--- a/server.go
+++ b/server.go
@@ -40,6 +40,8 @@ import (
 
 var logger *logging.Logger
 
+const tcpReadTimeout time.Duration = 59 * time.Second
+
 func init() {
 	var prefix = "%{level:.1s}%{time:2006-01-02T15:04:05.000Z07:00} %{pid} %{shortfile}]"
 	if terminal.IsTerminal(int(os.Stderr.Fd())) {
@@ -64,7 +66,6 @@ type SSServer struct {
 }
 
 func (s *SSServer) startPort(portNum int) error {
-	timeout := 59 * time.Second
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{Port: portNum})
 	if err != nil {
 		return fmt.Errorf("Failed to start TCP on port %v: %v", portNum, err)
@@ -76,7 +77,7 @@ func (s *SSServer) startPort(portNum int) error {
 	logger.Infof("Listening TCP and UDP on port %v", portNum)
 	port := &SSPort{cipherList: shadowsocks.NewCipherList()}
 	// TODO: Register initial data metrics at zero.
-	port.tcpService = shadowsocks.NewTCPService(listener, &port.cipherList, s.m, timeout)
+	port.tcpService = shadowsocks.NewTCPService(listener, &port.cipherList, s.m, tcpReadTimeout)
 	port.udpService = shadowsocks.NewUDPService(packetConn, s.natTimeout, &port.cipherList, s.m)
 	s.ports[portNum] = port
 	go port.udpService.Start()

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	logging "github.com/op/go-logging"
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+	logging "github.com/op/go-logging"
 )
 
 // Simulates receiving invalid TCP connection attempts on a server with 100 ciphers.
@@ -140,7 +140,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 		cipher := cipherEntries[cipherNumber].Cipher
 		go NewShadowsocksWriter(writer, cipher).Write(MakeTestPayload(50))
 		b.StartTimer()
-		_, _, err := findAccessKey(&c, cipherList)
+		_, _, _, err := findAccessKey(&c, cipherList)
 		b.StopTimer()
 		if err != nil {
 			b.Error(err)

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -140,7 +140,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 		cipher := cipherEntries[cipherNumber].Cipher
 		go NewShadowsocksWriter(writer, cipher).Write(MakeTestPayload(50))
 		b.StartTimer()
-		_, _, _, err := findAccessKey(&c, cipherList)
+		_, _, err := findAccessKey(&c, cipherList)
 		b.StopTimer()
 		if err != nil {
 			b.Error(err)


### PR DESCRIPTION
Implements resistance to probing by timing out after 59s if no valid cipher is found, regardless of how many bytes are sent.

@bemasc @fortuna