### PR TITLE
Fix segmentation fault when TCP accept fails

### DIFF
--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -175,6 +175,7 @@ func (s *tcpService) Start() {
 				return
 			}
 			logger.Errorf("Failed to accept: %v", err)
+			continue
 		}
 
 		go func() (connError *onet.ConnectionError) {


### PR DESCRIPTION
* When the server fails to accept a TCP connection, it only logs the error and attempts to proceed with the connection. This leads to a segmentation fault when calling `clientConn.RemoteAddress()`.
* This behavior has been observed when the server runs out of socket file descriptors.