### PR TITLE
Ensure thread safety on cipher updates

### DIFF
--- a/server.go
+++ b/server.go
@@ -79,8 +79,8 @@ func (s *SSServer) startPort(portNum int) error {
 	logger.Infof("Listening TCP and UDP on port %v", portNum)
 	port := &SSPort{cipherList: shadowsocks.NewCipherList()}
 	// TODO: Register initial data metrics at zero.
-	port.tcpService = shadowsocks.NewTCPService(listener, &port.cipherList, &s.replayCache, s.m, tcpReadTimeout)
-	port.udpService = shadowsocks.NewUDPService(packetConn, s.natTimeout, &port.cipherList, s.m)
+	port.tcpService = shadowsocks.NewTCPService(listener, port.cipherList, &s.replayCache, s.m, tcpReadTimeout)
+	port.udpService = shadowsocks.NewUDPService(packetConn, s.natTimeout, port.cipherList, s.m)
 	s.ports[portNum] = port
 	go port.udpService.Start()
 	go port.tcpService.Start()
@@ -148,7 +148,7 @@ func (s *SSServer) loadConfig(filename string) error {
 		}
 	}
 	for portNum, cipherList := range portCiphers {
-		s.ports[portNum].cipherList = cipherList
+		s.ports[portNum].cipherList.SafeSwap(cipherList)
 	}
 	logger.Infof("Loaded %v access keys", len(config.Keys))
 	s.m.SetNumAccessKeys(len(config.Keys), len(portCiphers))

--- a/shadowsocks/cipher_list.go
+++ b/shadowsocks/cipher_list.go
@@ -36,6 +36,7 @@ type CipherList interface {
 	PushBack(id string, cipher shadowaead.Cipher) *list.Element
 	SafeSnapshotForClientIP(clientIP net.IP) []*list.Element
 	SafeMarkUsedByClientIP(e *list.Element, clientIP net.IP)
+	SafeSwap(other CipherList)
 }
 
 type cipherList struct {
@@ -87,4 +88,13 @@ func (cl *cipherList) SafeMarkUsedByClientIP(e *list.Element, clientIP net.IP) {
 
 	c := e.Value.(*CipherEntry)
 	c.lastClientIP = clientIP
+}
+
+func (cl *cipherList) SafeSwap(other CipherList) {
+	cl2 := other.(*cipherList)
+	cl.mu.Lock()
+	cl2.mu.Lock()
+	cl.list, cl2.list = cl2.list, cl.list
+	cl2.mu.Unlock()
+	cl.mu.Unlock()
 }

--- a/shadowsocks/cipher_testing.go
+++ b/shadowsocks/cipher_testing.go
@@ -15,6 +15,7 @@
 package shadowsocks
 
 import (
+	"container/list"
 	"fmt"
 
 	"github.com/shadowsocks/go-shadowsocks2/core"
@@ -22,7 +23,7 @@ import (
 )
 
 func MakeTestCiphers(numCiphers int) (CipherList, error) {
-	cipherList := NewCipherList()
+	l := list.New()
 	for i := 0; i < numCiphers; i++ {
 		cipherID := fmt.Sprintf("id-%v", i)
 		secret := fmt.Sprintf("secret-%v", i)
@@ -30,8 +31,10 @@ func MakeTestCiphers(numCiphers int) (CipherList, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create cipher %v: %v", i, err)
 		}
-		cipherList.PushBack(cipherID, cipher.(shadowaead.Cipher))
+		l.PushBack(&CipherEntry{ID: cipherID, Cipher: cipher.(shadowaead.Cipher)})
 	}
+	cipherList := NewCipherList()
+	cipherList.Update(l)
 	return cipherList, nil
 }
 

--- a/shadowsocks/tcp.go
+++ b/shadowsocks/tcp.go
@@ -115,8 +115,7 @@ func findAccessKey(clientConn onet.DuplexConn, cipherList CipherList) (string, o
 
 type tcpService struct {
 	listener *net.TCPListener
-	// `ciphers` is a pointer to SSPort.cipherList, which can be updated by SSServer.loadConfig.
-	ciphers     *CipherList
+	ciphers     CipherList
 	m           metrics.ShadowsocksMetrics
 	isRunning   bool
 	readTimeout time.Duration
@@ -125,7 +124,7 @@ type tcpService struct {
 }
 
 // NewTCPService creates a TCPService
-func NewTCPService(listener *net.TCPListener, ciphers *CipherList, replayCache *ReplayCache, m metrics.ShadowsocksMetrics, timeout time.Duration) TCPService {
+func NewTCPService(listener *net.TCPListener, ciphers CipherList, replayCache *ReplayCache, m metrics.ShadowsocksMetrics, timeout time.Duration) TCPService {
 	return &tcpService{
 		listener:    listener,
 		ciphers:     ciphers,
@@ -219,7 +218,7 @@ func (s *tcpService) Start() {
 			}()
 
 			findStartTime := time.Now()
-			keyID, clientConn, salt, err := findAccessKey(clientConn, *s.ciphers)
+			keyID, clientConn, salt, err := findAccessKey(clientConn, s.ciphers)
 			timeToCipher = time.Now().Sub(findStartTime)
 
 			if err != nil {

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -130,7 +130,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 		b.Fatal(err)
 	}
 	cipherEntries := [numCiphers]*CipherEntry{}
-	for cipherNumber, element := range cipherList.SafeSnapshotForClientIP(nil) {
+	for cipherNumber, element := range cipherList.SnapshotForClientIP(nil) {
 		cipherEntries[cipherNumber] = element.Value.(*CipherEntry)
 	}
 	for n := 0; n < b.N; n++ {
@@ -195,7 +195,7 @@ func TestReplayDefense(t *testing.T) {
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
 	s := NewTCPService(listener, cipherList, &replayCache, testMetrics, testTimeout)
-	cipherEntry := cipherList.SafeSnapshotForClientIP(nil)[0].Value.(*CipherEntry)
+	cipherEntry := cipherList.SnapshotForClientIP(nil)[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
 	reader, writer := io.Pipe()
 	go NewShadowsocksWriter(writer, cipher).Write([]byte{0})

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -194,7 +194,7 @@ func TestReplayDefense(t *testing.T) {
 	replayCache := NewReplayCache(5)
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
-	s := NewTCPService(listener, &cipherList, &replayCache, testMetrics, testTimeout)
+	s := NewTCPService(listener, cipherList, &replayCache, testMetrics, testTimeout)
 	cipherEntry := cipherList.SafeSnapshotForClientIP(nil)[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
 	reader, writer := io.Pipe()
@@ -277,7 +277,7 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 		t.Fatal(err)
 	}
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(listener, &cipherList, nil, testMetrics, testTimeout)
+	s := NewTCPService(listener, cipherList, nil, testMetrics, testTimeout)
 
 	testPayload := MakeTestPayload(payloadSize)
 	done := make(chan bool)

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -60,13 +60,13 @@ func unpack(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, st
 type udpService struct {
 	clientConn net.PacketConn
 	natTimeout time.Duration
-	ciphers    *CipherList
+	ciphers    CipherList
 	m          metrics.ShadowsocksMetrics
 	isRunning  bool
 }
 
 // NewUDPService creates a UDPService
-func NewUDPService(clientConn net.PacketConn, natTimeout time.Duration, cipherList *CipherList, m metrics.ShadowsocksMetrics) UDPService {
+func NewUDPService(clientConn net.PacketConn, natTimeout time.Duration, cipherList CipherList, m metrics.ShadowsocksMetrics) UDPService {
 	return &udpService{clientConn: clientConn, natTimeout: natTimeout, ciphers: cipherList, m: m}
 }
 
@@ -122,7 +122,7 @@ func (s *udpService) Start() {
 			logger.Debugf("UDP Request from %v with %v bytes", clientAddr, clientProxyBytes)
 			unpackStart := time.Now()
 			ip := clientAddr.(*net.UDPAddr).IP
-			buf, keyID, cipher, err := unpack(ip, textBuf, cipherBuf[:clientProxyBytes], *s.ciphers)
+			buf, keyID, cipher, err := unpack(ip, textBuf, cipherBuf[:clientProxyBytes], s.ciphers)
 			timeToCipher = time.Now().Sub(unpackStart)
 
 			if err != nil {

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -38,7 +38,7 @@ const udpBufSize = 64 * 1024
 func unpack(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.Cipher, error) {
 	// Try each cipher until we find one that authenticates successfully. This assumes that all ciphers are AEAD.
 	// We snapshot the list because it may be modified while we use it.
-	for ci, entry := range cipherList.SafeSnapshotForClientIP(clientIP) {
+	for ci, entry := range cipherList.SnapshotForClientIP(clientIP) {
 		id, cipher := entry.Value.(*CipherEntry).ID, entry.Value.(*CipherEntry).Cipher
 		buf, err := shadowaead.Unpack(dst, src, cipher)
 		if err != nil {
@@ -51,7 +51,7 @@ func unpack(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, st
 			logger.Debugf("UDP: Found cipher %v at index %d", id, ci)
 		}
 		// Move the active cipher to the front, so that the search is quicker next time.
-		cipherList.SafeMarkUsedByClientIP(entry, clientIP)
+		cipherList.MarkUsedByClientIP(entry, clientIP)
 		return buf, id, cipher, nil
 	}
 	return nil, "", nil, errors.New("could not find valid cipher")

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -52,7 +52,7 @@ func BenchmarkUDPUnpackRepeat(b *testing.B) {
 	testBuf := make([]byte, udpBufSize)
 	packets := [numCiphers][]byte{}
 	ips := [numCiphers]net.IP{}
-	for i, element := range cipherList.SafeSnapshotForClientIP(nil) {
+	for i, element := range cipherList.SnapshotForClientIP(nil) {
 		packets[i] = make([]byte, 0, udpBufSize)
 		plaintext := MakeTestPayload(50)
 		packets[i], err = shadowaead.Pack(make([]byte, udpBufSize), plaintext, element.Value.(*CipherEntry).Cipher)
@@ -84,7 +84,7 @@ func BenchmarkUDPUnpackSharedKey(b *testing.B) {
 	}
 	testBuf := make([]byte, udpBufSize)
 	plaintext := MakeTestPayload(50)
-	cipher := cipherList.SafeSnapshotForClientIP(nil)[0].Value.(*CipherEntry).Cipher
+	cipher := cipherList.SnapshotForClientIP(nil)[0].Value.(*CipherEntry).Cipher
 	packet, err := shadowaead.Pack(make([]byte, udpBufSize), plaintext, cipher)
 
 	const numIPs = 100 // Must be <256


### PR DESCRIPTION
This change makes cipher updates a thread-safe operation, and
avoids the unusual pointer-to-interface construction.