### PR TITLE
Reuse a bytes.Reader in shadowsocksWriter

### DIFF
--- a/shadowsocks/stream.go
+++ b/shadowsocks/stream.go
@@ -37,6 +37,8 @@ type Writer interface {
 type shadowsocksWriter struct {
 	writer   io.Writer
 	ssCipher shadowaead.Cipher
+	// Wrapper for input that arrives as a slice.
+	input bytes.Reader
 	// These are lazily initialized:
 	buf  []byte
 	aead cipher.AEAD
@@ -80,7 +82,8 @@ func (sw *shadowsocksWriter) encryptBlock(ciphertext []byte, plaintext []byte) (
 }
 
 func (sw *shadowsocksWriter) Write(p []byte) (int, error) {
-	n, err := sw.ReadFrom(bytes.NewReader(p))
+	sw.input.Reset(p)
+	n, err := sw.ReadFrom(&sw.input)
 	return int(n), err
 }
 

--- a/shadowsocks/stream.go
+++ b/shadowsocks/stream.go
@@ -38,7 +38,7 @@ type shadowsocksWriter struct {
 	writer   io.Writer
 	ssCipher shadowaead.Cipher
 	// Wrapper for input that arrives as a slice.
-	input bytes.Reader
+	byteWrapper bytes.Reader
 	// These are lazily initialized:
 	buf  []byte
 	aead cipher.AEAD
@@ -82,8 +82,8 @@ func (sw *shadowsocksWriter) encryptBlock(ciphertext []byte, plaintext []byte) (
 }
 
 func (sw *shadowsocksWriter) Write(p []byte) (int, error) {
-	sw.input.Reset(p)
-	n, err := sw.ReadFrom(&sw.input)
+	sw.byteWrapper.Reset(p)
+	n, err := sw.ReadFrom(&sw.byteWrapper)
 	return int(n), err
 }
 


### PR DESCRIPTION
This avoids a memory allocation in every call to Write.

Master:
    BenchmarkTCPThroughput-4   	   64716	     18246 ns/op	       438 mbps	      81 B/op	       2 allocs/op

This branch:
    BenchmarkTCPThroughput-4   	   68146	     17924 ns/op	       446 mbps	      33 B/op	       1 allocs/op