### PR TITLE
Store client location in the NAT map

### DIFF
--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -176,7 +176,9 @@ func (s *udpService) Stop() error {
 }
 
 type natentry struct {
-	conn           net.PacketConn
+	conn net.PacketConn
+	// We store the client location in the NAT map to avoid recomputing it
+	// for every outbound packet in a UDP-based connection.
 	clientLocation string
 }
 


### PR DESCRIPTION
This avoids searching the GeoIP table for every
outgoing UDP packet in a QUIC or WebRTC connection.