### PR TITLE
Fix flaky test

### DIFF
--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -288,12 +288,12 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 	done := make(chan bool)
 	go func() {
 		defer func() { done <- true }()
+		timerStart := time.Now()
 		conn, err := net.Dial("tcp", listener.Addr().String())
 		if err != nil {
 			t.Fatalf("Failed to dial %v: %v", listener.Addr(), err)
 		}
 		conn.Write(testPayload)
-		timerStart := time.Now()
 		buf := make([]byte, 1024)
 		bytesRead, err := conn.Read(buf) // will hang until connection is closed
 		elapsedTime := time.Since(timerStart)


### PR DESCRIPTION
This test is time-based so it has some inherent unreliability, but it's
currently comparing time intervals that are slightly out of order, which
is leading to sporadic failures in my testing. This change puts the
intervals in the correct order and makes the test reliable for me
locally.