### PR TITLE
Remove Summaries and reorganize cipher search

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -19,7 +19,8 @@ func TestMethodsDontPanic(t *testing.T) {
 	}
 	ssMetrics.SetNumAccessKeys(20, 2)
 	ssMetrics.AddOpenTCPConnection("US")
-	ssMetrics.AddClosedTCPConnection("US", "1", "OK", proxyMetrics, 10*time.Millisecond, 100*time.Millisecond)
+	ssMetrics.AddTCPCipherSearch(50*time.Microsecond, true)
+	ssMetrics.AddClosedTCPConnection("US", "1", "OK", proxyMetrics, 100*time.Millisecond)
 	ssMetrics.AddTCPProbe("US", "ERR_CIPHER", "eof", 443, proxyMetrics)
 	ssMetrics.AddUDPPacketFromClient("US", "2", "OK", 10, 20, 10*time.Millisecond)
 	ssMetrics.AddUDPPacketFromTarget("US", "3", "OK", 10, 20)
@@ -63,11 +64,10 @@ func BenchmarkCloseTCP(b *testing.B) {
 	accessKey := "key 1"
 	status := "OK"
 	data := ProxyMetrics{}
-	timeToCipher := time.Microsecond
 	duration := time.Minute
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ssMetrics.AddClosedTCPConnection(clientLocation, accessKey, status, data, timeToCipher, duration)
+		ssMetrics.AddClosedTCPConnection(clientLocation, accessKey, status, data, duration)
 	}
 }
 
@@ -115,5 +115,13 @@ func BenchmarkNAT(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ssMetrics.AddUDPNatEntry()
 		ssMetrics.RemoveUDPNatEntry()
+	}
+}
+
+func BenchmarkTCPCipherSearch(b *testing.B) {
+	ssMetrics := NewPrometheusShadowsocksMetrics(nil, prometheus.NewRegistry())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ssMetrics.AddTCPCipherSearch(50*time.Microsecond, true)
 	}
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -19,8 +19,7 @@ func TestMethodsDontPanic(t *testing.T) {
 	}
 	ssMetrics.SetNumAccessKeys(20, 2)
 	ssMetrics.AddOpenTCPConnection("US")
-	ssMetrics.AddTCPCipherSearch(50*time.Microsecond, true)
-	ssMetrics.AddClosedTCPConnection("US", "1", "OK", proxyMetrics, 100*time.Millisecond)
+	ssMetrics.AddClosedTCPConnection("US", "1", "OK", proxyMetrics, 10*time.Millisecond, 100*time.Millisecond)
 	ssMetrics.AddTCPProbe("US", "ERR_CIPHER", "eof", 443, proxyMetrics)
 	ssMetrics.AddUDPPacketFromClient("US", "2", "OK", 10, 20, 10*time.Millisecond)
 	ssMetrics.AddUDPPacketFromTarget("US", "3", "OK", 10, 20)
@@ -64,10 +63,11 @@ func BenchmarkCloseTCP(b *testing.B) {
 	accessKey := "key 1"
 	status := "OK"
 	data := ProxyMetrics{}
+	timeToCipher := time.Microsecond
 	duration := time.Minute
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ssMetrics.AddClosedTCPConnection(clientLocation, accessKey, status, data, duration)
+		ssMetrics.AddClosedTCPConnection(clientLocation, accessKey, status, data, timeToCipher, duration)
 	}
 }
 
@@ -115,13 +115,5 @@ func BenchmarkNAT(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ssMetrics.AddUDPNatEntry()
 		ssMetrics.RemoveUDPNatEntry()
-	}
-}
-
-func BenchmarkTCPCipherSearch(b *testing.B) {
-	ssMetrics := NewPrometheusShadowsocksMetrics(nil, prometheus.NewRegistry())
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ssMetrics.AddTCPCipherSearch(50*time.Microsecond, true)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -136,9 +136,6 @@ func (s *ssServer) loadConfig(filename string) error {
 		if !ok {
 			return fmt.Errorf("Only AEAD ciphers are supported. Found %v", keyConfig.Cipher)
 		}
-		if err := shadowsocks.CheckCipher(aead); err != nil {
-			return fmt.Errorf("Cipher is not supported: %v", err)
-		}
 		cipherList.PushBack(&shadowsocks.CipherEntry{ID: keyConfig.ID, Cipher: aead})
 	}
 	for port := range s.ports {
@@ -156,7 +153,9 @@ func (s *ssServer) loadConfig(filename string) error {
 		}
 	}
 	for portNum, cipherList := range portCiphers {
-		s.ports[portNum].cipherList.Update(cipherList)
+		if err := s.ports[portNum].cipherList.Update(cipherList); err != nil {
+			return err
+		}
 	}
 	logger.Infof("Loaded %v access keys", len(config.Keys))
 	s.m.SetNumAccessKeys(len(config.Keys), len(portCiphers))

--- a/server.go
+++ b/server.go
@@ -136,6 +136,9 @@ func (s *ssServer) loadConfig(filename string) error {
 		if !ok {
 			return fmt.Errorf("Only AEAD ciphers are supported. Found %v", keyConfig.Cipher)
 		}
+		if err := shadowsocks.CheckCipher(aead); err != nil {
+			return fmt.Errorf("Cipher is not supported: %v", err)
+		}
 		cipherList.PushBack(&shadowsocks.CipherEntry{ID: keyConfig.ID, Cipher: aead})
 	}
 	for port := range s.ports {

--- a/shadowsocks/cipher_list.go
+++ b/shadowsocks/cipher_list.go
@@ -17,6 +17,7 @@ package shadowsocks
 import (
 	"container/list"
 	"fmt"
+	"math"
 	"net"
 	"sync"
 
@@ -25,61 +26,6 @@ import (
 
 // All ciphers must have a nonce size this big or smaller.
 const maxNonceSize = 12
-
-// Describes the size parameters of a cipher.
-type cipherSize struct {
-	salt, overhead int
-}
-
-// These are cipher size parameters supported by CipherList.
-// To support TCP trial decryption, these sizes must not include
-// too wide a range.  Otherwise, trial decryption for a large-size
-// cipher could block indefinitely, when the client has actually
-// sent a handshake for a short cipher.
-//
-// Ciphers do not need to have exactly the same size because a minimal
-// handshake (from a short cipher) includes at least one additional
-// AEAD tag, providing enough bytes for trial decryption with a
-// longer cipher.
-var supportedSizes = [...]cipherSize{
-	{32, 16}, // chacha20poly1305, AES-256-GCM
-	{24, 16}, // AES-192-GCM
-	{16, 16}, // AES-128-GCM
-}
-
-// Minimum number of bytes to read for trial decryption of all supported
-// ciphers.
-var tcpHeader int
-
-func init() {
-	for _, s := range supportedSizes {
-		t := s.salt + 2 + s.overhead
-		if t > tcpHeader {
-			tcpHeader = t
-		}
-	}
-}
-
-// CheckCipher checks whether the provided cipher is compatible with CipherList.
-func CheckCipher(cipher shadowaead.Cipher) error {
-	saltsize := cipher.SaltSize()
-	aead, err := cipher.Decrypter(make([]byte, saltsize))
-	if err != nil {
-		return err
-	}
-
-	if aead.NonceSize() > maxNonceSize {
-		return fmt.Errorf("Nonce size is too large: %d > %d", aead.NonceSize(), maxNonceSize)
-	}
-	size := cipherSize{saltsize, aead.Overhead()}
-
-	for _, s := range supportedSizes {
-		if s == size {
-			return nil
-		}
-	}
-	return fmt.Errorf("Unsupported cipher size: %v", size)
-}
 
 // CipherEntry holds a Cipher with an identifier.
 // The public fields are constant, but lastAddress is mutable under cipherList.mu.
@@ -92,18 +38,21 @@ type CipherEntry struct {
 // CipherList is a thread-safe collection of CipherEntry elements that allows for
 // snapshotting and moving to front.
 type CipherList interface {
-	SnapshotForClientIP(clientIP net.IP) []*list.Element
+	// Returns a snapshot of the cipher list optimized for this client IP,
+	// and also the number of bytes needed for TCP trial decryption.
+	SnapshotForClientIP(clientIP net.IP) (int, []*list.Element)
 	MarkUsedByClientIP(e *list.Element, clientIP net.IP)
 	// Update replaces the current contents of the CipherList with `contents`,
 	// which is a List of *CipherEntry.  Update takes ownership of `contents`,
 	// which must not be read or written after this call.
-	Update(contents *list.List)
+	Update(contents *list.List) error
 }
 
 type cipherList struct {
 	CipherList
-	list *list.List
-	mu   sync.RWMutex
+	list         *list.List
+	mu           sync.RWMutex
+	tcpTrialSize int
 }
 
 // NewCipherList creates an empty CipherList
@@ -116,7 +65,7 @@ func matchesIP(e *list.Element, clientIP net.IP) bool {
 	return clientIP != nil && clientIP.Equal(c.lastClientIP)
 }
 
-func (cl *cipherList) SnapshotForClientIP(clientIP net.IP) []*list.Element {
+func (cl *cipherList) SnapshotForClientIP(clientIP net.IP) (int, []*list.Element) {
 	cl.mu.RLock()
 	defer cl.mu.RUnlock()
 	cipherArray := make([]*list.Element, cl.list.Len())
@@ -135,7 +84,7 @@ func (cl *cipherList) SnapshotForClientIP(clientIP net.IP) []*list.Element {
 			i++
 		}
 	}
-	return cipherArray
+	return cl.tcpTrialSize, cipherArray
 }
 
 func (cl *cipherList) MarkUsedByClientIP(e *list.Element, clientIP net.IP) {
@@ -147,8 +96,53 @@ func (cl *cipherList) MarkUsedByClientIP(e *list.Element, clientIP net.IP) {
 	c.lastClientIP = clientIP
 }
 
-func (cl *cipherList) Update(src *list.List) {
+func tcpHeaderBounds(cipher shadowaead.Cipher) (requires, provides int, err error) {
+	saltSize := cipher.SaltSize()
+
+	aead, err := cipher.Decrypter(make([]byte, saltSize))
+	if err != nil {
+		return
+	}
+
+	if aead.NonceSize() > maxNonceSize {
+		err = fmt.Errorf("Cipher has oversize nonce: %v", cipher)
+		return
+	}
+	overhead := aead.Overhead()
+
+	// We need at least this many bytes to assess whether a TCP stream corresponds
+	// to this cipher.
+	requires = saltSize + 2 + overhead
+	// Any TCP stream for this cipher will deliver at least this many bytes before
+	// requiring the proxy to act.
+	provides = requires + overhead
+	return
+}
+
+func (cl *cipherList) Update(src *list.List) error {
+	maxRequired := 0
+	minProvided := int(math.MaxInt32) // Very large initial value
+	for e := src.Front(); e != nil; e = e.Next() {
+		cipher := e.Value.(*CipherEntry).Cipher
+		requires, provides, err := tcpHeaderBounds(cipher)
+		if err != nil {
+			return err
+		}
+
+		if requires > maxRequired {
+			maxRequired = requires
+		}
+		if provides < minProvided {
+			minProvided = provides
+		}
+	}
+	if maxRequired > minProvided {
+		return fmt.Errorf("List contains incompatible ciphers: %d > %d", maxRequired, minProvided)
+	}
+
 	cl.mu.Lock()
 	cl.list = src
+	cl.tcpTrialSize = maxRequired
 	cl.mu.Unlock()
+	return nil
 }

--- a/shadowsocks/cipher_list_test.go
+++ b/shadowsocks/cipher_list_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadowsocks
+
+import (
+	"crypto/cipher"
+	"testing"
+
+	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
+)
+
+type fakeAEAD struct {
+	cipher.AEAD
+	overhead, nonceSize int
+}
+
+func (a *fakeAEAD) NonceSize() int {
+	return a.nonceSize
+}
+
+func (a *fakeAEAD) Overhead() int {
+	return a.overhead
+}
+
+type fakeCipher struct {
+	shadowaead.Cipher
+	saltsize  int
+	decrypter *fakeAEAD
+}
+
+func (c *fakeCipher) SaltSize() int {
+	return c.saltsize
+}
+
+func (c *fakeCipher) Decrypter(b []byte) (cipher.AEAD, error) {
+	return c.decrypter, nil
+}
+
+func TestIncompatibleCiphers(t *testing.T) {
+	smallSalt := &fakeCipher{saltsize: 8, decrypter: &fakeAEAD{overhead: 16, nonceSize: 12}}
+	oddSalt := &fakeCipher{saltsize: 23, decrypter: &fakeAEAD{overhead: 16, nonceSize: 12}}
+	bigSalt := &fakeCipher{saltsize: 64, decrypter: &fakeAEAD{overhead: 16, nonceSize: 12}}
+	smallOverhead := &fakeCipher{saltsize: 8, decrypter: &fakeAEAD{overhead: 8, nonceSize: 12}}
+	bigOverhead := &fakeCipher{saltsize: 8, decrypter: &fakeAEAD{overhead: 8, nonceSize: 12}}
+	bigNonce := &fakeCipher{saltsize: 32, decrypter: &fakeAEAD{overhead: 16, nonceSize: 13}}
+
+	ciphers := [...]shadowaead.Cipher{
+		smallSalt, oddSalt, bigSalt,
+		smallOverhead, bigOverhead,
+		bigNonce,
+	}
+	for _, c := range ciphers {
+		if err := CheckCipher(c); err == nil {
+			t.Errorf("Expected error when checking cipher: %v", c)
+		}
+	}
+}
+
+func TestCompatibleCiphers(t *testing.T) {
+	smallSalt := &fakeCipher{saltsize: 16, decrypter: &fakeAEAD{overhead: 16, nonceSize: 12}}
+	bigSalt := &fakeCipher{saltsize: 32, decrypter: &fakeAEAD{overhead: 16, nonceSize: 12}}
+	smallNonce := &fakeCipher{saltsize: 16, decrypter: &fakeAEAD{overhead: 16, nonceSize: 10}}
+
+	ciphers := [...]shadowaead.Cipher{smallSalt, bigSalt, smallNonce}
+	for _, c := range ciphers {
+		if err := CheckCipher(c); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestRealCiphers(t *testing.T) {
+	chacha, err := shadowaead.Chacha20Poly1305(make([]byte, 32))
+	if err != nil {
+		t.Error(err)
+	}
+	aes256, err := shadowaead.AESGCM(make([]byte, 32))
+	if err != nil {
+		t.Error(err)
+	}
+	aes192, err := shadowaead.AESGCM(make([]byte, 24))
+	if err != nil {
+		t.Error(err)
+	}
+	aes128, err := shadowaead.AESGCM(make([]byte, 16))
+	if err != nil {
+		t.Error(err)
+	}
+
+	ciphers := [...]shadowaead.Cipher{
+		chacha, aes256, aes192, aes128,
+	}
+	for _, c := range ciphers {
+		if err := CheckCipher(c); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestTCPHeader(t *testing.T) {
+	for _, s := range supportedSizes {
+		required := s.salt + 2 + s.overhead
+		if required > tcpHeader {
+			t.Error("Cipher requires too many bytes")
+		}
+
+		// Minimum length initial delivery is a complete zero-length chunk
+		provided := required + s.overhead
+		if provided < tcpHeader {
+			t.Error("Cipher doesn't provide enough bytes")
+		}
+	}
+}

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -56,7 +56,7 @@ func BenchmarkTCPFindCipherFail(b *testing.B) {
 			b.Fatalf("AcceptTCP failed: %v", err)
 		}
 		b.StartTimer()
-		findAccessKey(clientConn, cipherList)
+		findAccessKey(clientConn, cipherList, nil)
 		b.StopTimer()
 	}
 }
@@ -141,7 +141,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 		cipher := cipherEntries[cipherNumber].Cipher
 		go NewShadowsocksWriter(writer, cipher).Write(MakeTestPayload(50))
 		b.StartTimer()
-		_, _, _, err := findAccessKey(&c, cipherList)
+		_, _, _, err := findAccessKey(&c, cipherList, nil)
 		b.StopTimer()
 		if err != nil {
 			b.Error(err)
@@ -162,7 +162,7 @@ func (m *probeTestMetrics) AddTCPProbe(clientLocation, status, drainResult strin
 	m.probeData = append(m.probeData, data)
 	m.probeStatus = append(m.probeStatus, status)
 }
-func (m *probeTestMetrics) AddClosedTCPConnection(clientLocation, accessKey, status string, data metrics.ProxyMetrics, timeToCipher, duration time.Duration) {
+func (m *probeTestMetrics) AddClosedTCPConnection(clientLocation, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
 	m.closeStatus = append(m.closeStatus, status)
 }
 
@@ -172,6 +172,8 @@ func (m *probeTestMetrics) GetLocation(net.Addr) (string, error) {
 func (m *probeTestMetrics) SetNumAccessKeys(numKeys int, numPorts int) {
 }
 func (m *probeTestMetrics) AddOpenTCPConnection(clientLocation string) {
+}
+func (m *probeTestMetrics) AddTCPCipherSearch(timeToCipher time.Duration, foundKey bool) {
 }
 func (m *probeTestMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
 }

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -55,7 +55,8 @@ func debugUDPAddr(addr net.Addr, template string, val interface{}) {
 func unpack(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.Cipher, error) {
 	// Try each cipher until we find one that authenticates successfully. This assumes that all ciphers are AEAD.
 	// We snapshot the list because it may be modified while we use it.
-	for ci, entry := range cipherList.SnapshotForClientIP(clientIP) {
+	_, snapshot := cipherList.SnapshotForClientIP(clientIP)
+	for ci, entry := range snapshot {
 		id, cipher := entry.Value.(*CipherEntry).ID, entry.Value.(*CipherEntry).Cipher
 		buf, err := shadowaead.Unpack(dst, src, cipher)
 		if err != nil {

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -52,7 +52,8 @@ func BenchmarkUDPUnpackRepeat(b *testing.B) {
 	testBuf := make([]byte, udpBufSize)
 	packets := [numCiphers][]byte{}
 	ips := [numCiphers]net.IP{}
-	for i, element := range cipherList.SnapshotForClientIP(nil) {
+	_, snapshot := cipherList.SnapshotForClientIP(nil)
+	for i, element := range snapshot {
 		packets[i] = make([]byte, 0, udpBufSize)
 		plaintext := MakeTestPayload(50)
 		packets[i], err = shadowaead.Pack(make([]byte, udpBufSize), plaintext, element.Value.(*CipherEntry).Cipher)
@@ -84,7 +85,8 @@ func BenchmarkUDPUnpackSharedKey(b *testing.B) {
 	}
 	testBuf := make([]byte, udpBufSize)
 	plaintext := MakeTestPayload(50)
-	cipher := cipherList.SnapshotForClientIP(nil)[0].Value.(*CipherEntry).Cipher
+	_, snapshot := cipherList.SnapshotForClientIP(nil)
+	cipher := snapshot[0].Value.(*CipherEntry).Cipher
 	packet, err := shadowaead.Pack(make([]byte, udpBufSize), plaintext, cipher)
 
 	const numIPs = 100 // Must be <256


### PR DESCRIPTION
This avoids a slow increase in memory usage on heavily used servers by
replacing the Summaries with Histograms and reducing the number of
dimensions.  It also reorganizes the cipher search to make the "Time to
Cipher" metric measure only the CPU time, as originally intended.