### PR TITLE
Allow clients to concatenate the first 2 packets

### DIFF
--- a/shadowsocks/client_test.go
+++ b/shadowsocks/client_test.go
@@ -29,7 +29,11 @@ func TestShadowsocksClient_DialTCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create ShadowsocksClient: %v", err)
 	}
-	conn, err := d.DialTCP(nil, testTargetAddr)
+	proxyConn, err := d.DialProxyTCP(nil)
+	if err != nil {
+		t.Fatalf("ShadowsocksClient.DialProxyTCP failed: %v", err)
+	}
+	conn, err := d.DialDestinationTCP(proxyConn, testTargetAddr, nil)
 	if err != nil {
 		t.Fatalf("ShadowsocksClient.DialTCP failed: %v", err)
 	}
@@ -71,7 +75,11 @@ func BenchmarkShadowsocksClient_DialTCP(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create ShadowsocksClient: %v", err)
 	}
-	conn, err := d.DialTCP(nil, testTargetAddr)
+	proxyConn, err := d.DialProxyTCP(nil)
+	if err != nil {
+		b.Fatalf("ShadowsocksClient.DialProxyTCP failed: %v", err)
+	}
+	conn, err := d.DialDestinationTCP(proxyConn, testTargetAddr, nil)
 	if err != nil {
 		b.Fatalf("ShadowsocksClient.DialTCP failed: %v", err)
 	}

--- a/shadowsocks/integration_test.go
+++ b/shadowsocks/integration_test.go
@@ -109,7 +109,11 @@ func TestTCPEcho(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create ShadowsocksClient: %v", err)
 	}
-	conn, err := client.DialTCP(nil, echoListener.Addr().String())
+	proxyConn, err := client.DialProxyTCP(nil)
+	if err != nil {
+		t.Fatalf("ShadowsocksClient.DialProxyTCP failed: %v", err)
+	}
+	conn, err := client.DialDestinationTCP(proxyConn, echoListener.Addr().String(), nil)
 	if err != nil {
 		t.Fatalf("ShadowsocksClient.DialTCP failed: %v", err)
 	}
@@ -302,7 +306,11 @@ func BenchmarkTCPThroughput(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create ShadowsocksClient: %v", err)
 	}
-	conn, err := client.DialTCP(nil, echoListener.Addr().String())
+	proxyConn, err := client.DialProxyTCP(nil)
+	if err != nil {
+		b.Fatalf("ShadowsocksClient.DialProxyTCP failed: %v", err)
+	}
+	conn, err := client.DialDestinationTCP(proxyConn, echoListener.Addr().String(), nil)
 	if err != nil {
 		b.Fatalf("ShadowsocksClient.DialTCP failed: %v", err)
 	}
@@ -384,7 +392,11 @@ func BenchmarkTCPMultiplexing(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < k; i++ {
-				conn, err := client.DialTCP(nil, echoListener.Addr().String())
+				proxyConn, err := client.DialProxyTCP(nil)
+				if err != nil {
+					b.Fatalf("ShadowsocksClient.DialProxyTCP failed: %v", err)
+				}
+				conn, err := client.DialDestinationTCP(proxyConn, echoListener.Addr().String(), nil)
 				if err != nil {
 					b.Fatalf("ShadowsocksClient.DialTCP failed: %v", err)
 				}


### PR DESCRIPTION
This gives clients the option to bundle the destination address with the
first payload for that address.