### PR TITLE
Make tests pass under the race detector

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,9 +29,10 @@ jobs:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
         fi
+        git submodule update --init
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -v -race -bench=. ./... -benchtime=100ms

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,7 @@ jobs:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
         fi
+        # Download GeoIP test data from MaxMind
         git submodule update --init
 
     - name: Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ language: go
 go:
 - "1.14"
 - "stable"
+
+script:
+ - go test -v -race -bench=. ./... -benchtime=100ms

--- a/net/private_net.go
+++ b/net/private_net.go
@@ -45,6 +45,9 @@ func IsPrivateAddress(ip net.IP) bool {
 	return false
 }
 
+// IPPolicy is a type alias for checking if an IP is allowed.
+type IPPolicy = func(net.IP) *ConnectionError
+
 // RequirePublicIP returns an error if the destination IP is not a
 // standard public IP.
 func RequirePublicIP(ip net.IP) *ConnectionError {

--- a/server.go
+++ b/server.go
@@ -84,11 +84,9 @@ func (s *ssServer) startPort(portNum int) error {
 	logger.Infof("Listening TCP and UDP on port %v", portNum)
 	port := &ssPort{cipherList: shadowsocks.NewCipherList()}
 	// TODO: Register initial data metrics at zero.
-	port.tcpService = shadowsocks.NewTCPService(listener, port.cipherList, &s.replayCache, s.m, tcpReadTimeout)
-	port.udpService = shadowsocks.NewUDPService(packetConn, s.natTimeout, port.cipherList, s.m)
+	port.tcpService = shadowsocks.NewTCPService(listener, port.cipherList, &s.replayCache, s.m, tcpReadTimeout, nil)
+	port.udpService = shadowsocks.NewUDPService(packetConn, s.natTimeout, port.cipherList, s.m, nil)
 	s.ports[portNum] = port
-	go port.udpService.Start()
-	go port.tcpService.Start()
 	return nil
 }
 
@@ -97,8 +95,8 @@ func (s *ssServer) removePort(portNum int) error {
 	if !ok {
 		return fmt.Errorf("Port %v doesn't exist", portNum)
 	}
-	tcpErr := port.tcpService.Stop()
-	udpErr := port.udpService.Stop()
+	tcpErr := port.tcpService.Close()
+	udpErr := port.udpService.Close()
 	delete(s.ports, portNum)
 	if tcpErr != nil {
 		return fmt.Errorf("Failed to close listener on %v: %v", portNum, tcpErr)

--- a/shadowsocks/tcp_test.go
+++ b/shadowsocks/tcp_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,12 +27,15 @@ import (
 	logging "github.com/op/go-logging"
 )
 
+func init() {
+	logging.SetLevel(logging.INFO, "")
+}
+
 // Simulates receiving invalid TCP connection attempts on a server with 100 ciphers.
 func BenchmarkTCPFindCipherFail(b *testing.B) {
 	b.StopTimer()
 	b.ResetTimer()
 
-	logging.SetLevel(logging.INFO, "")
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	if err != nil {
 		b.Fatalf("ListenTCP failed: %v", err)
@@ -122,8 +126,6 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 	b.StopTimer()
 	b.ResetTimer()
 
-	logging.SetLevel(logging.INFO, "")
-
 	const numCiphers = 100 // Must be <256
 	cipherList, err := MakeTestCiphers(MakeTestSecrets(numCiphers))
 	if err != nil {
@@ -154,17 +156,22 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 // Stub metrics implementation for testing replay defense.
 type probeTestMetrics struct {
 	metrics.ShadowsocksMetrics
+	mu          sync.Mutex
 	probeData   []metrics.ProxyMetrics
 	probeStatus []string
 	closeStatus []string
 }
 
 func (m *probeTestMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data metrics.ProxyMetrics) {
+	m.mu.Lock()
 	m.probeData = append(m.probeData, data)
 	m.probeStatus = append(m.probeStatus, status)
+	m.mu.Unlock()
 }
 func (m *probeTestMetrics) AddClosedTCPConnection(clientLocation, accessKey, status string, data metrics.ProxyMetrics, timeToCipher, duration time.Duration) {
+	m.mu.Lock()
 	m.closeStatus = append(m.closeStatus, status)
+	m.mu.Unlock()
 }
 
 func (m *probeTestMetrics) GetLocation(net.Addr) (string, error) {
@@ -182,8 +189,6 @@ func (m *probeTestMetrics) AddUDPNatEntry()    {}
 func (m *probeTestMetrics) RemoveUDPNatEntry() {}
 
 func TestReplayDefense(t *testing.T) {
-	logging.SetLevel(logging.DEBUG, "")
-
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	if err != nil {
 		t.Fatalf("ListenTCP failed: %v", err)
@@ -195,7 +200,7 @@ func TestReplayDefense(t *testing.T) {
 	replayCache := NewReplayCache(5)
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
-	s := NewTCPService(listener, cipherList, &replayCache, testMetrics, testTimeout)
+	s := NewTCPService(listener, cipherList, &replayCache, testMetrics, testTimeout, nil)
 	_, snapshot := cipherList.SnapshotForClientIP(nil)
 	cipherEntry := snapshot[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
@@ -218,8 +223,6 @@ func TestReplayDefense(t *testing.T) {
 		return conn
 	}
 
-	go s.Start()
-
 	// First run.
 	conn1 := run()
 	if len(testMetrics.probeData) != 0 {
@@ -238,6 +241,11 @@ func TestReplayDefense(t *testing.T) {
 	conn2 := run()
 	// Wait for the connection to be closed by the proxy after testTimeout.
 	conn2.Read(make([]byte, 1))
+
+	conn1.Close()
+	s.Close()
+	s.Wait()
+
 	if len(testMetrics.probeData) == 1 {
 		data := testMetrics.probeData[0]
 		if data.ClientProxy != int64(len(preamble)) {
@@ -258,15 +266,11 @@ func TestReplayDefense(t *testing.T) {
 	} else {
 		t.Error("Replay should have reported an error status")
 	}
-
-	conn1.Close()
-	s.Stop()
 }
 
 // Test 49, 50, and 51 bytes to ensure they have the same behavior.
 // 50 bytes used to be the cutoff for different behavior.
 func TestTCPProbeTimeout(t *testing.T) {
-	logging.SetLevel(logging.CRITICAL, "")
 	probeExpectTimeout(t, 49)
 	probeExpectTimeout(t, 50)
 	probeExpectTimeout(t, 51)
@@ -284,7 +288,7 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 		t.Fatal(err)
 	}
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(listener, cipherList, nil, testMetrics, testTimeout)
+	s := NewTCPService(listener, cipherList, nil, testMetrics, testTimeout, nil)
 
 	testPayload := MakeTestPayload(payloadSize)
 	done := make(chan bool)
@@ -311,8 +315,9 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 		}
 	}()
 
-	go s.Start()
 	<-done
+	s.Close()
+	s.Wait()
 
 	if len(testMetrics.probeData) == 1 {
 		data := testMetrics.probeData[0]
@@ -338,6 +343,4 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 	} else {
 		t.Error("Bad handshake should have reported an error status")
 	}
-
-	s.Stop()
 }

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -95,14 +96,14 @@ func assertAlmostEqual(t *testing.T, a, b time.Time) {
 }
 
 func TestNATEmpty(t *testing.T) {
-	nat := newNATmap(timeout, &probeTestMetrics{})
+	nat := newNATmap(timeout, &probeTestMetrics{}, &sync.WaitGroup{})
 	if nat.Get("foo") != nil {
 		t.Error("Expected nil value from empty NAT map")
 	}
 }
 
 func setup() (*fakePacketConn, *fakePacketConn, *natconn) {
-	nat := newNATmap(timeout, &probeTestMetrics{})
+	nat := newNATmap(timeout, &probeTestMetrics{}, &sync.WaitGroup{})
 	clientConn := makePacketConn()
 	targetConn := makePacketConn()
 	nat.Add(&clientAddr, clientConn, natCipher, targetConn, "ZZ", "key id")


### PR DESCRIPTION
This required fixing a race between Start() and Stop(), and also several
races in the test code.

This change also removes some goroutine leaks in the client tests, and
adds the race detector to the Travis presubmit