### PR TITLE
Avoid UDP cipher search if a NAT mapping exists

### DIFF
--- a/shadowsocks/cipher_list_test.go
+++ b/shadowsocks/cipher_list_test.go
@@ -17,6 +17,8 @@ package shadowsocks
 import (
 	"container/list"
 	"crypto/cipher"
+	"math/rand"
+	"net"
 	"testing"
 
 	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
@@ -86,4 +88,45 @@ func TestCompatibleCiphers(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func BenchmarkLocking(b *testing.B) {
+	var ip net.IP
+
+	ciphers, _ := MakeTestCiphers(MakeTestSecrets(1))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, entries := ciphers.SnapshotForClientIP(nil)
+			ciphers.MarkUsedByClientIP(entries[0], ip)
+		}
+	})
+}
+
+func BenchmarkSnapshot(b *testing.B) {
+	// Create a list of cipher entries in a random order.
+
+	// Small cipher lists (N~1e3) fit entirely in cache, and are ~10 times
+	// faster to copy (per entry) than very large cipher lists (N~1e5).
+	const N = 1e3
+	ciphers, _ := MakeTestCiphers(MakeTestSecrets(N))
+
+	// Shuffling simulates the behavior of a real server, where successive
+	// ciphers are not expected to be nearby in memory.
+	_, entries := ciphers.SnapshotForClientIP(nil)
+	rand.Shuffle(N, func(i, j int) {
+		entries[i], entries[j] = entries[j], entries[i]
+	})
+	for _, entry := range entries {
+		// Reorder the list to match the shuffle
+		// (actually in reverse, but it doesn't matter).
+		ciphers.MarkUsedByClientIP(entry, nil)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ciphers.SnapshotForClientIP(nil)
+		}
+	})
 }

--- a/shadowsocks/integration_test.go
+++ b/shadowsocks/integration_test.go
@@ -515,12 +515,15 @@ func BenchmarkUDPManyKeys(b *testing.B) {
 
 	const N = 1000
 	buf := make([]byte, N)
+	conns := make([]net.PacketConn, len(clients))
+	for i, client := range clients {
+		conns[i], _ = client.ListenUDP(nil)
+	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		conn, _ := clients[i%numKeys].ListenUDP(nil)
+		conn := conns[i%numKeys]
 		conn.WriteTo(buf, echoConn.LocalAddr())
 		conn.ReadFrom(buf)
-		conn.Close()
 	}
 	b.StopTimer()
 	proxy.Stop()

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -50,9 +50,9 @@ func debugUDPAddr(addr net.Addr, template string, val interface{}) {
 	}
 }
 
-// upack decrypts src into dst. It tries each cipher until it finds one that authenticates
+// Decrypts src into dst. It tries each cipher until it finds one that authenticates
 // correctly. dst and src must not overlap.
-func unpack(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.Cipher, error) {
+func findAccessKeyUDP(clientIP net.IP, dst, src []byte, cipherList CipherList) ([]byte, string, shadowaead.Cipher, error) {
 	// Try each cipher until we find one that authenticates successfully. This assumes that all ciphers are AEAD.
 	// We snapshot the list because it may be modified while we use it.
 	_, snapshot := cipherList.SnapshotForClientIP(clientIP)
@@ -177,7 +177,7 @@ func (s *udpService) Serve(clientConn net.PacketConn) error {
 				ip := clientAddr.(*net.UDPAddr).IP
 				var cipher shadowaead.Cipher
 				unpackStart := time.Now()
-				textData, keyID, cipher, err = unpack(ip, textBuf, cipherData, s.ciphers)
+				textData, keyID, cipher, err = findAccessKeyUDP(ip, textBuf, cipherData, s.ciphers)
 				timeToCipher = time.Now().Sub(unpackStart)
 
 				if err != nil {

--- a/shadowsocks/udp.go
+++ b/shadowsocks/udp.go
@@ -163,16 +163,43 @@ func (s *udpService) Serve(clientConn net.PacketConn) error {
 				defer logger.Debugf("UDP(%v): done", clientAddr)
 				logger.Debugf("UDP(%v): Outbound packet has %d bytes", clientAddr, clientProxyBytes)
 			}
-			unpackStart := time.Now()
-			ip := clientAddr.(*net.UDPAddr).IP
-			buf, keyID, cipher, err := unpack(ip, textBuf, cipherBuf[:clientProxyBytes], s.ciphers)
-			timeToCipher = time.Now().Sub(unpackStart)
 
-			if err != nil {
-				return onet.NewConnectionError("ERR_CIPHER", "Failed to upack data from client", err)
+			cipherData := cipherBuf[:clientProxyBytes]
+			var textData []byte
+			targetConn := nm.Get(clientAddr.String())
+			if targetConn == nil {
+				clientLocation, locErr := s.m.GetLocation(clientAddr)
+				if locErr != nil {
+					logger.Warningf("Failed location lookup: %v", locErr)
+				}
+				debugUDPAddr(clientAddr, "Got location \"%s\"", clientLocation)
+
+				ip := clientAddr.(*net.UDPAddr).IP
+				var cipher shadowaead.Cipher
+				unpackStart := time.Now()
+				textData, keyID, cipher, err = unpack(ip, textBuf, cipherData, s.ciphers)
+				timeToCipher = time.Now().Sub(unpackStart)
+
+				if err != nil {
+					return onet.NewConnectionError("ERR_CIPHER", "Failed to unpack initial packet", err)
+				}
+
+				udpConn, err := net.ListenPacket("udp", "")
+				if err != nil {
+					return onet.NewConnectionError("ERR_CREATE_SOCKET", "Failed to create UDP socket", err)
+				}
+				targetConn = nm.Add(clientAddr, clientConn, cipher, udpConn, clientLocation, keyID)
+			} else {
+				unpackStart := time.Now()
+				textData, err = shadowaead.Unpack(textBuf, cipherData, targetConn.cipher)
+				timeToCipher = time.Now().Sub(unpackStart)
+				if err != nil {
+					return onet.NewConnectionError("ERR_CIPHER", "Failed to unpack data from client", err)
+				}
 			}
+			clientLocation = targetConn.clientLocation
 
-			tgtAddr := socks.SplitAddr(buf)
+			tgtAddr := socks.SplitAddr(textData)
 			if tgtAddr == nil {
 				return onet.NewConnectionError("ERR_READ_ADDRESS", "Failed to get target address", nil)
 			}
@@ -185,25 +212,8 @@ func (s *udpService) Serve(clientConn net.PacketConn) error {
 				return err
 			}
 
-			payload := buf[len(tgtAddr):]
-
-			targetConn := nm.Get(clientAddr.String())
-			if targetConn == nil {
-				clientLocation, locErr := s.m.GetLocation(clientAddr)
-				if locErr != nil {
-					logger.Warningf("Failed location lookup: %v", locErr)
-				}
-				debugUDPAddr(clientAddr, "Got location \"%s\"", clientLocation)
-
-				udpConn, err := net.ListenPacket("udp", "")
-				if err != nil {
-					return onet.NewConnectionError("ERR_CREATE_SOCKET", "Failed to create UDP socket", err)
-				}
-				targetConn = nm.Add(clientAddr, clientConn, cipher, udpConn, clientLocation, keyID)
-			}
-			clientLocation = targetConn.clientLocation
-
 			debugUDPAddr(clientAddr, "Proxy exit %v", targetConn.LocalAddr())
+			payload := textData[len(tgtAddr):]
 			proxyTargetBytes, err = targetConn.WriteTo(payload, tgtUDPAddr) // accept only UDPAddr despite the signature
 			if err != nil {
 				return onet.NewConnectionError("ERR_WRITE", "Failed to write to target", err)
@@ -237,6 +247,7 @@ func isDNS(addr net.Addr) bool {
 
 type natconn struct {
 	net.PacketConn
+	cipher shadowaead.Cipher
 	// We store the client location in the NAT map to avoid recomputing it
 	// for every downstream packet in a UDP-based connection.
 	clientLocation string
@@ -317,9 +328,10 @@ func (m *natmap) Get(key string) *natconn {
 	return m.keyConn[key]
 }
 
-func (m *natmap) set(key string, pc net.PacketConn, clientLocation string) *natconn {
+func (m *natmap) set(key string, pc net.PacketConn, cipher shadowaead.Cipher, clientLocation string) *natconn {
 	entry := &natconn{
 		PacketConn:     pc,
+		cipher:         cipher,
 		clientLocation: clientLocation,
 		defaultTimeout: m.timeout,
 	}
@@ -344,12 +356,12 @@ func (m *natmap) del(key string) net.PacketConn {
 }
 
 func (m *natmap) Add(clientAddr net.Addr, clientConn net.PacketConn, cipher shadowaead.Cipher, targetConn net.PacketConn, clientLocation, keyID string) *natconn {
-	entry := m.set(clientAddr.String(), targetConn, clientLocation)
+	entry := m.set(clientAddr.String(), targetConn, cipher, clientLocation)
 
 	m.metrics.AddUDPNatEntry()
 	m.running.Add(1)
 	go func() {
-		timedCopy(clientAddr, clientConn, cipher, entry, keyID, m.metrics)
+		timedCopy(clientAddr, clientConn, entry, keyID, m.metrics)
 		m.metrics.RemoveUDPNatEntry()
 		if pc := m.del(clientAddr.String()); pc != nil {
 			pc.Close()
@@ -378,14 +390,14 @@ func (m *natmap) Close() error {
 var maxAddrLen int = len(socks.ParseAddr("[2001:db8::1]:12345"))
 
 // copy from target to client until read timeout
-func timedCopy(clientAddr net.Addr, clientConn net.PacketConn, cipher shadowaead.Cipher, targetConn *natconn,
+func timedCopy(clientAddr net.Addr, clientConn net.PacketConn, targetConn *natconn,
 	keyID string, sm metrics.ShadowsocksMetrics) {
 	// pkt is used for in-place encryption of downstream UDP packets, with the layout
 	// [padding?][salt][address][body][tag][extra]
 	// Padding is only used if the address is IPv4.
 	pkt := make([]byte, udpBufSize)
 
-	saltSize := cipher.SaltSize()
+	saltSize := targetConn.cipher.SaltSize()
 	// Leave enough room at the beginning of the packet for a max-length header (i.e. IPv6).
 	bodyStart := saltSize + maxAddrLen
 
@@ -429,7 +441,7 @@ func timedCopy(clientAddr net.Addr, clientConn net.PacketConn, cipher shadowaead
 			//           [            packBuf             ]
 			//           [          buf           ]
 			packBuf := pkt[saltStart:]
-			buf, err := shadowaead.Pack(packBuf, plaintextBuf, cipher) // Encrypt in-place
+			buf, err := shadowaead.Pack(packBuf, plaintextBuf, targetConn.cipher) // Encrypt in-place
 			if err != nil {
 				return onet.NewConnectionError("ERR_PACK", "Failed to pack data to client", err)
 			}

--- a/shadowsocks/udp_test.go
+++ b/shadowsocks/udp_test.go
@@ -297,7 +297,7 @@ func BenchmarkUDPUnpackFail(b *testing.B) {
 	testIP := net.ParseIP("192.0.2.1")
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		unpack(testIP, textBuf, testPayload, cipherList)
+		findAccessKeyUDP(testIP, textBuf, testPayload, cipherList)
 	}
 }
 
@@ -327,7 +327,7 @@ func BenchmarkUDPUnpackRepeat(b *testing.B) {
 		cipherNumber := n % numCiphers
 		ip := ips[cipherNumber]
 		packet := packets[cipherNumber]
-		_, _, _, err := unpack(ip, testBuf, packet, cipherList)
+		_, _, _, err := findAccessKeyUDP(ip, testBuf, packet, cipherList)
 		if err != nil {
 			b.Error(err)
 		}
@@ -355,7 +355,7 @@ func BenchmarkUDPUnpackSharedKey(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		ip := ips[n%numIPs]
-		_, _, _, err := unpack(ip, testBuf, packet, cipherList)
+		_, _, _, err := findAccessKeyUDP(ip, testBuf, packet, cipherList)
 		if err != nil {
 			b.Error(err)
 		}


### PR DESCRIPTION
This change limits the UDP cipher search to the first packet on a NAT
mapping.  Subsequent packets use the cipher associated with the NAT
mapping.  This assumes that multiple keys do not share a client port,
but that assumption was already in place for the downstream connection,
which uses a fixed cipher for the duration of a NAT mapping.

This makes UDP streams perform similarly to TCP.

The BenchmarkUDPManyKeys test was reusing the same client port with
multiple ciphers (and not attempting to decrypt the returned packets),
so it had to be modified to avoid client port reuse.  The new version of
that test shows the effect of this optimization:

Before:
BenchmarkUDPManyKeys-4       1660    752446 ns/op  130564 B/op    1740 allocs/op

After:
BenchmarkUDPManyKeys-4      12822     90546 ns/op    6845 B/op     112 allocs/op

This test is something of a worst-case scenario (100 keys on the same
IP, interleaved), so real usage won't show such a large improvement.

In real use, the main benefit is in avoiding copying of the cipher
list on every packet.  The new BenchmarkSnapshot test shows that this
takes ~5 ns per key on my laptop.  Decryption takes 7000 ns, so copying
the list dominates the upstream CPU usage of UDP streams on servers with
1500+ keys.