### PR TITLE
Clean up and simplify cipher code

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,7 +12,6 @@ import (
 
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
-	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 )
 
@@ -205,7 +204,7 @@ func startShadowsocksTCPEchoProxy(expectedTgtAddr string, t testing.TB) (net.Lis
 		t.Fatalf("ListenTCP failed: %v", err)
 	}
 	t.Logf("Starting SS TCP echo proxy at %v\n", listener.Addr())
-	cipher, err := newAeadCipher(ss.TestCipher, testPassword)
+	cipher, err := ss.NewCipher(ss.TestCipher, testPassword)
 	if err != nil {
 		t.Fatalf("Failed to create cipher: %v", err)
 	}
@@ -250,7 +249,7 @@ func startShadowsocksUDPEchoServer(expectedTgtAddr string, t testing.TB) (net.Co
 	t.Logf("Starting SS UDP echo proxy at %v\n", conn.LocalAddr())
 	cipherBuf := make([]byte, clientUDPBufferSize)
 	clientBuf := make([]byte, clientUDPBufferSize)
-	cipher, err := newAeadCipher(ss.TestCipher, testPassword)
+	cipher, err := ss.NewCipher(ss.TestCipher, testPassword)
 	if err != nil {
 		t.Fatalf("Failed to create cipher: %v", err)
 	}
@@ -265,7 +264,7 @@ func startShadowsocksUDPEchoServer(expectedTgtAddr string, t testing.TB) (net.Co
 				t.Logf("Failed to read from UDP conn: %v", err)
 				return
 			}
-			buf, err := shadowaead.Unpack(clientBuf, cipherBuf[:n], cipher)
+			buf, err := ss.Unpack(clientBuf, cipherBuf[:n], cipher)
 			if err != nil {
 				t.Fatalf("Failed to decrypt: %v", err)
 			}
@@ -277,7 +276,7 @@ func startShadowsocksUDPEchoServer(expectedTgtAddr string, t testing.TB) (net.Co
 				t.Fatalf("Expected target address '%v'. Got '%v'", expectedTgtAddr, tgtAddr)
 			}
 			// Echo both the payload and SOCKS address.
-			buf, err = shadowaead.Pack(cipherBuf, buf, cipher)
+			buf, err = ss.Pack(cipherBuf, buf, cipher)
 			if err != nil {
 				t.Fatalf("Failed to encrypt: %v", err)
 			}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -257,7 +257,7 @@ func TestUDPEcho(t *testing.T) {
 	echoRunning.Wait()
 	proxy.GracefulStop()
 	// Verify that the expected metrics were reported.
-	_, snapshot := cipherList.SnapshotForClientIP(nil)
+	snapshot := cipherList.SnapshotForClientIP(nil)
 	keyID := snapshot[0].Value.(*service.CipherEntry).ID
 
 	if testMetrics.natAdded != 1 {

--- a/service/cipher_list.go
+++ b/service/cipher_list.go
@@ -55,8 +55,7 @@ func MakeCipherEntry(id string, cipher *ss.Cipher, secret string) CipherEntry {
 // CipherList is a thread-safe collection of CipherEntry elements that allows for
 // snapshotting and moving to front.
 type CipherList interface {
-	// Returns a snapshot of the cipher list optimized for this client IP,
-	// and also the number of bytes needed for TCP trial decryption.
+	// Returns a snapshot of the cipher list optimized for this client IP
 	SnapshotForClientIP(clientIP net.IP) []*list.Element
 	MarkUsedByClientIP(e *list.Element, clientIP net.IP)
 	// Update replaces the current contents of the CipherList with `contents`,

--- a/service/cipher_list.go
+++ b/service/cipher_list.go
@@ -16,16 +16,11 @@ package service
 
 import (
 	"container/list"
-	"fmt"
-	"math"
 	"net"
 	"sync"
 
-	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
+	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
 )
-
-// All ciphers must have a nonce size this big or smaller.
-const maxNonceSize = 12
 
 // Don't add a tag if it would reduce the salt entropy below this amount.
 const minSaltEntropy = 16
@@ -34,13 +29,13 @@ const minSaltEntropy = 16
 // The public fields are constant, but lastClientIP is mutable under cipherList.mu.
 type CipherEntry struct {
 	ID            string
-	Cipher        shadowaead.Cipher
+	Cipher        *ss.Cipher
 	SaltGenerator ServerSaltGenerator
 	lastClientIP  net.IP
 }
 
 // MakeCipherEntry constructs a CipherEntry.
-func MakeCipherEntry(id string, cipher shadowaead.Cipher, secret string) CipherEntry {
+func MakeCipherEntry(id string, cipher *ss.Cipher, secret string) CipherEntry {
 	var saltGenerator ServerSaltGenerator
 	if cipher.SaltSize()-ServerSaltMarkLen >= minSaltEntropy {
 		// Mark salts with a tag for reverse replay protection.
@@ -62,19 +57,18 @@ func MakeCipherEntry(id string, cipher shadowaead.Cipher, secret string) CipherE
 type CipherList interface {
 	// Returns a snapshot of the cipher list optimized for this client IP,
 	// and also the number of bytes needed for TCP trial decryption.
-	SnapshotForClientIP(clientIP net.IP) (int, []*list.Element)
+	SnapshotForClientIP(clientIP net.IP) []*list.Element
 	MarkUsedByClientIP(e *list.Element, clientIP net.IP)
 	// Update replaces the current contents of the CipherList with `contents`,
 	// which is a List of *CipherEntry.  Update takes ownership of `contents`,
 	// which must not be read or written after this call.
-	Update(contents *list.List) error
+	Update(contents *list.List)
 }
 
 type cipherList struct {
 	CipherList
-	list         *list.List
-	mu           sync.RWMutex
-	tcpTrialSize int
+	list *list.List
+	mu   sync.RWMutex
 }
 
 // NewCipherList creates an empty CipherList
@@ -87,7 +81,7 @@ func matchesIP(e *list.Element, clientIP net.IP) bool {
 	return clientIP != nil && clientIP.Equal(c.lastClientIP)
 }
 
-func (cl *cipherList) SnapshotForClientIP(clientIP net.IP) (int, []*list.Element) {
+func (cl *cipherList) SnapshotForClientIP(clientIP net.IP) []*list.Element {
 	cl.mu.RLock()
 	defer cl.mu.RUnlock()
 	cipherArray := make([]*list.Element, cl.list.Len())
@@ -106,7 +100,7 @@ func (cl *cipherList) SnapshotForClientIP(clientIP net.IP) (int, []*list.Element
 			i++
 		}
 	}
-	return cl.tcpTrialSize, cipherArray
+	return cipherArray
 }
 
 func (cl *cipherList) MarkUsedByClientIP(e *list.Element, clientIP net.IP) {
@@ -118,53 +112,8 @@ func (cl *cipherList) MarkUsedByClientIP(e *list.Element, clientIP net.IP) {
 	c.lastClientIP = clientIP
 }
 
-func tcpHeaderBounds(cipher shadowaead.Cipher) (requires, provides int, err error) {
-	saltSize := cipher.SaltSize()
-
-	aead, err := cipher.Decrypter(make([]byte, saltSize))
-	if err != nil {
-		return
-	}
-
-	if aead.NonceSize() > maxNonceSize {
-		err = fmt.Errorf("Cipher has oversize nonce: %v", cipher)
-		return
-	}
-	overhead := aead.Overhead()
-
-	// We need at least this many bytes to assess whether a TCP stream corresponds
-	// to this cipher.
-	requires = saltSize + 2 + overhead
-	// Any TCP stream for this cipher will deliver at least this many bytes before
-	// requiring the proxy to act.
-	provides = requires + overhead
-	return
-}
-
-func (cl *cipherList) Update(src *list.List) error {
-	maxRequired := 0
-	minProvided := int(math.MaxInt32) // Very large initial value
-	for e := src.Front(); e != nil; e = e.Next() {
-		cipher := e.Value.(*CipherEntry).Cipher
-		requires, provides, err := tcpHeaderBounds(cipher)
-		if err != nil {
-			return err
-		}
-
-		if requires > maxRequired {
-			maxRequired = requires
-		}
-		if provides < minProvided {
-			minProvided = provides
-		}
-	}
-	if maxRequired > minProvided {
-		return fmt.Errorf("List contains incompatible ciphers: %d > %d", maxRequired, minProvided)
-	}
-
+func (cl *cipherList) Update(src *list.List) {
 	cl.mu.Lock()
 	cl.list = src
-	cl.tcpTrialSize = maxRequired
 	cl.mu.Unlock()
-	return nil
 }

--- a/service/cipher_list_test.go
+++ b/service/cipher_list_test.go
@@ -26,7 +26,7 @@ import (
 func TestCompatibleCiphers(t *testing.T) {
 	maxRequired := 0
 	minProvided := int(math.MaxInt32) // Very large initial value
-	for _, cipherName := range ss.SuportedCipherNames {
+	for _, cipherName := range ss.SuportedCipherNames() {
 		cipher, _ := ss.NewCipher(cipherName, "dummy secret")
 		// We need at least this many bytes to assess whether a TCP stream corresponds
 		// to this cipher.

--- a/service/cipher_list_test.go
+++ b/service/cipher_list_test.go
@@ -26,7 +26,7 @@ import (
 func TestCompatibleCiphers(t *testing.T) {
 	maxRequired := 0
 	minProvided := int(math.MaxInt32) // Very large initial value
-	for _, cipherName := range ss.SuportedCipherNames() {
+	for _, cipherName := range ss.SupportedCipherNames() {
 		cipher, _ := ss.NewCipher(cipherName, "dummy secret")
 		// We need at least this many bytes to assess whether a TCP stream corresponds
 		// to this cipher.

--- a/service/cipher_list_test.go
+++ b/service/cipher_list_test.go
@@ -15,36 +15,12 @@
 package service
 
 import (
-	"math"
 	"math/rand"
 	"net"
 	"testing"
 
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
 )
-
-func TestCompatibleCiphers(t *testing.T) {
-	maxRequired := 0
-	minProvided := int(math.MaxInt32) // Very large initial value
-	for _, cipherName := range ss.SupportedCipherNames() {
-		cipher, _ := ss.NewCipher(cipherName, "dummy secret")
-		// We need at least this many bytes to assess whether a TCP stream corresponds
-		// to this cipher.
-		requires := cipher.SaltSize() + 2 + cipher.TagSize()
-		if requires > maxRequired {
-			maxRequired = requires
-		}
-		// Any TCP stream for this cipher will deliver at least this many bytes before
-		// requiring the proxy to act.
-		provides := requires + cipher.TagSize()
-		if provides < minProvided {
-			minProvided = provides
-		}
-	}
-	if maxRequired > minProvided {
-		t.Fatalf("Supported ciphers contains incompatible ciphers: %d > %d", maxRequired, minProvided)
-	}
-}
 
 func BenchmarkLocking(b *testing.B) {
 	var ip net.IP

--- a/service/cipher_list_test.go
+++ b/service/cipher_list_test.go
@@ -15,79 +15,34 @@
 package service
 
 import (
-	"container/list"
-	"crypto/cipher"
+	"math"
 	"math/rand"
 	"net"
 	"testing"
 
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
-	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
 )
 
-type fakeAEAD struct {
-	cipher.AEAD
-	overhead, nonceSize int
-}
-
-func (a *fakeAEAD) NonceSize() int {
-	return a.nonceSize
-}
-
-func (a *fakeAEAD) Overhead() int {
-	return a.overhead
-}
-
-type fakeCipher struct {
-	shadowaead.Cipher
-	saltsize  int
-	decrypter *fakeAEAD
-}
-
-func (c *fakeCipher) SaltSize() int {
-	return c.saltsize
-}
-
-func (c *fakeCipher) Decrypter(b []byte) (cipher.AEAD, error) {
-	return c.decrypter, nil
-}
-
-func TestIncompatibleCiphers(t *testing.T) {
-	l := list.New()
-	l.PushBack(&CipherEntry{
-		ID:     "short",
-		Cipher: &fakeCipher{saltsize: 5, decrypter: &fakeAEAD{overhead: 3}}})
-	l.PushBack(&CipherEntry{ID: "long", Cipher: &fakeCipher{saltsize: 50, decrypter: &fakeAEAD{overhead: 30}}})
-	cipherList := NewCipherList()
-	err := cipherList.Update(l)
-	if err == nil {
-		t.Error("Expected Update to fail due to incompatible ciphers")
-	}
-}
-
-func TestMaxNonceSize(t *testing.T) {
-	l := list.New()
-	l.PushBack(&CipherEntry{
-		ID:     "oversize nonce",
-		Cipher: &fakeCipher{saltsize: 5, decrypter: &fakeAEAD{overhead: 3, nonceSize: 13}}})
-	l.PushBack(&CipherEntry{ID: "long", Cipher: &fakeCipher{saltsize: 50, decrypter: &fakeAEAD{overhead: 30}}})
-	cipherList := NewCipherList()
-	err := cipherList.Update(l)
-	if err == nil {
-		t.Error("Expected Update to fail due to oversize nonce")
-	}
-}
-
 func TestCompatibleCiphers(t *testing.T) {
-	chacha20, _ := shadowaead.Chacha20Poly1305(make([]byte, 32))
-	aes128, _ := shadowaead.AESGCM(make([]byte, 16))
-	l := list.New()
-	l.PushBack(&CipherEntry{ID: "aes128", Cipher: aes128})
-	l.PushBack(&CipherEntry{ID: "chacha20", Cipher: chacha20})
-	cipherList := NewCipherList()
-	err := cipherList.Update(l)
-	if err != nil {
-		t.Error(err)
+	maxRequired := 0
+	minProvided := int(math.MaxInt32) // Very large initial value
+	for _, cipherName := range ss.SuportedCipherNames {
+		cipher, _ := ss.NewCipher(cipherName, "dummy secret")
+		// We need at least this many bytes to assess whether a TCP stream corresponds
+		// to this cipher.
+		requires := cipher.SaltSize() + 2 + cipher.TagSize()
+		if requires > maxRequired {
+			maxRequired = requires
+		}
+		// Any TCP stream for this cipher will deliver at least this many bytes before
+		// requiring the proxy to act.
+		provides := requires + cipher.TagSize()
+		if provides < minProvided {
+			minProvided = provides
+		}
+	}
+	if maxRequired > minProvided {
+		t.Fatalf("Supported ciphers contains incompatible ciphers: %d > %d", maxRequired, minProvided)
 	}
 }
 
@@ -98,7 +53,7 @@ func BenchmarkLocking(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, entries := ciphers.SnapshotForClientIP(nil)
+			entries := ciphers.SnapshotForClientIP(nil)
 			ciphers.MarkUsedByClientIP(entries[0], ip)
 		}
 	})
@@ -114,7 +69,7 @@ func BenchmarkSnapshot(b *testing.B) {
 
 	// Shuffling simulates the behavior of a real server, where successive
 	// ciphers are not expected to be nearby in memory.
-	_, entries := ciphers.SnapshotForClientIP(nil)
+	entries := ciphers.SnapshotForClientIP(nil)
 	rand.Shuffle(N, func(i, j int) {
 		entries[i], entries[j] = entries[j], entries[i]
 	})

--- a/service/cipher_list_testing.go
+++ b/service/cipher_list_testing.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
-	"github.com/shadowsocks/go-shadowsocks2/core"
-	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
 )
 
 // MakeTestCiphers creates a CipherList containing one fresh AEAD cipher
@@ -29,11 +27,11 @@ func MakeTestCiphers(secrets []string) (CipherList, error) {
 	l := list.New()
 	for i := 0; i < len(secrets); i++ {
 		cipherID := fmt.Sprintf("id-%v", i)
-		cipher, err := core.PickCipher(ss.TestCipher, nil, secrets[i])
+		cipher, err := ss.NewCipher(ss.TestCipher, secrets[i])
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create cipher %v: %v", i, err)
 		}
-		entry := MakeCipherEntry(cipherID, cipher.(shadowaead.Cipher), secrets[i])
+		entry := MakeCipherEntry(cipherID, cipher, secrets[i])
 		l.PushBack(&entry)
 	}
 	cipherList := NewCipherList()

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -134,7 +134,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 		b.Fatal(err)
 	}
 	cipherEntries := [numCiphers]*CipherEntry{}
-	_, snapshot := cipherList.SnapshotForClientIP(nil)
+	snapshot := cipherList.SnapshotForClientIP(nil)
 	for cipherNumber, element := range snapshot {
 		cipherEntries[cipherNumber] = element.Value.(*CipherEntry)
 	}
@@ -204,7 +204,7 @@ func TestReplayDefense(t *testing.T) {
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
 	s := NewTCPService(cipherList, &replayCache, testMetrics, testTimeout)
-	_, snapshot := cipherList.SnapshotForClientIP(nil)
+	snapshot := cipherList.SnapshotForClientIP(nil)
 	cipherEntry := snapshot[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
 	reader, writer := io.Pipe()
@@ -285,7 +285,7 @@ func TestReverseReplayDefense(t *testing.T) {
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
 	s := NewTCPService(cipherList, &replayCache, testMetrics, testTimeout)
-	_, snapshot := cipherList.SnapshotForClientIP(nil)
+	snapshot := cipherList.SnapshotForClientIP(nil)
 	cipherEntry := snapshot[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
 	reader, writer := io.Pipe()

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -67,6 +67,24 @@ func BenchmarkTCPFindCipherFail(b *testing.B) {
 	}
 }
 
+func TestCompatibleCiphers(t *testing.T) {
+	for _, cipherName := range ss.SupportedCipherNames() {
+		cipher, _ := ss.NewCipher(cipherName, "dummy secret")
+		// We need at least this many bytes to assess whether a TCP stream corresponds
+		// to this cipher.
+		requires := cipher.SaltSize() + 2 + cipher.TagSize()
+		if requires > bytesForKeyFinding {
+			t.Errorf("Cipher %v required %v bytes > bytesForKeyFinding (%v)", cipherName, requires, bytesForKeyFinding)
+		}
+		// Any TCP stream for this cipher will deliver at least this many bytes before
+		// requiring the proxy to act.
+		provides := requires + cipher.TagSize()
+		if provides < bytesForKeyFinding {
+			t.Errorf("Cipher %v provides %v bytes < bytesForKeyFinding (%v)", cipherName, provides, bytesForKeyFinding)
+		}
+	}
+}
+
 // Fake DuplexConn
 // 1-way pipe, representing the upstream flow as seen by the server.
 type conn struct {

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -82,10 +82,12 @@ func (c *Cipher) TagSize() int {
 	return c.aead.tagSize
 }
 
+var subkeyInfo = []byte("ss-subkey")
+
 // NewAEAD creates the AEAD for this cipher
 func (c *Cipher) NewAEAD(salt []byte) (cipher.AEAD, error) {
 	sessionKey := make([]byte, c.aead.keySize)
-	r := hkdf.New(sha1.New, c.secret, salt, []byte("ss-subkey"))
+	r := hkdf.New(sha1.New, c.secret, salt, subkeyInfo)
 	if _, err := io.ReadFull(r, sessionKey); err != nil {
 		return nil, err
 	}

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -116,7 +116,7 @@ func NewCipher(cipherName string, secretText string) (*Cipher, error) {
 // Assumes all ciphers have NonceSize() <= 12.
 var zeroNonce [12]byte
 
-// DecryptOnce will decrypt the cipherText using the cipher and salt, outputting to plainText.
+// DecryptOnce will decrypt the cipherText using the cipher and salt, appending the output to plainText.
 func DecryptOnce(cipher *Cipher, salt []byte, plainText, cipherText []byte) ([]byte, error) {
 	aead, err := cipher.NewAEAD(salt)
 	if err != nil {

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -27,13 +27,12 @@ import (
 )
 
 // SuportedCipherNames lists the names of the AEAD ciphers that are supported.
-var SuportedCipherNames []string
-
-func init() {
-	SuportedCipherNames = make([]string, len(supportedAEADs))
+func SuportedCipherNames() []string {
+	names := make([]string, len(supportedAEADs))
 	for i, spec := range supportedAEADs {
-		SuportedCipherNames[i] = spec.name
+		names[i] = spec.name
 	}
+	return names
 }
 
 type aeadSpec struct {

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -26,8 +26,8 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// SuportedCipherNames lists the names of the AEAD ciphers that are supported.
-func SuportedCipherNames() []string {
+// SupportedCipherNames lists the names of the AEAD ciphers that are supported.
+func SupportedCipherNames() []string {
 	names := make([]string, len(supportedAEADs))
 	for i, spec := range supportedAEADs {
 		names[i] = spec.name

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -1,0 +1,132 @@
+// Copyright 2020 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadowsocks
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/hkdf"
+)
+
+// SuportedCipherNames lists the names of the AEAD ciphers that are supported.
+var SuportedCipherNames []string
+
+func init() {
+	SuportedCipherNames = make([]string, len(supportedAEADs))
+	for i, spec := range supportedAEADs {
+		SuportedCipherNames[i] = spec.name
+	}
+}
+
+type aeadSpec struct {
+	name        string
+	newInstance func(key []byte) (cipher.AEAD, error)
+	keySize     int
+	tagSize     int
+}
+
+// List of supported AEAD ciphers, as specified at https://shadowsocks.org/en/spec/AEAD-Ciphers.html
+var supportedAEADs = []aeadSpec{
+	newAeadSpec("chacha20-ietf-poly1305", chacha20poly1305.New, chacha20poly1305.KeySize),
+	newAeadSpec("aes-256-gcm", newAesGCM, 32),
+	newAeadSpec("aes-192-gcm", newAesGCM, 24),
+	newAeadSpec("aes-128-gcm", newAesGCM, 16),
+}
+
+func newAeadSpec(name string, newInstance func(key []byte) (cipher.AEAD, error), keySize int) aeadSpec {
+	dummyAead, err := newInstance(make([]byte, keySize))
+	if err != nil {
+		panic(fmt.Sprintf("Failed to initialize AEAD %v", name))
+	}
+	return aeadSpec{name, newInstance, keySize, dummyAead.Overhead()}
+}
+
+func newAesGCM(key []byte) (cipher.AEAD, error) {
+	blk, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(blk)
+}
+
+// Cipher encapsulates a Shadowsocks AEAD spec and a secret
+type Cipher struct {
+	aead   aeadSpec
+	secret []byte
+}
+
+// SaltSize is the size of the salt for this Cipher
+func (c *Cipher) SaltSize() int {
+	return c.aead.keySize
+}
+
+// TagSize is the size of the AEAD tag for this Cipher
+func (c *Cipher) TagSize() int {
+	return c.aead.tagSize
+}
+
+// NewAEAD creates the AEAD for this cipher
+func (c *Cipher) NewAEAD(salt []byte) (cipher.AEAD, error) {
+	sessionKey := make([]byte, c.aead.keySize)
+	r := hkdf.New(sha1.New, c.secret, salt, []byte("ss-subkey"))
+	if _, err := io.ReadFull(r, sessionKey); err != nil {
+		return nil, err
+	}
+	return c.aead.newInstance(sessionKey)
+}
+
+func getAEADSpec(name string) (*aeadSpec, error) {
+	name = strings.ToLower(name)
+	for _, aeadSpec := range supportedAEADs {
+		if aeadSpec.name == name {
+			return &aeadSpec, nil
+		}
+	}
+	return nil, fmt.Errorf("Unknown cipher %v", name)
+}
+
+// NewCipher creates a Cipher given a cipher name and a secret
+func NewCipher(cipherName string, secretText string) (*Cipher, error) {
+	secret := []byte(secretText)
+	aeadSpec, err := getAEADSpec(cipherName)
+	if err != nil {
+		return nil, err
+	}
+	return &Cipher{*aeadSpec, secret}, nil
+}
+
+// Assumes all ciphers have NonceSize() <= 12.
+var zeroNonce [12]byte
+
+// DecryptOnce will decrypt the cipherText using the cipher and salt, outputting to plainText.
+func DecryptOnce(cipher *Cipher, salt []byte, plainText, cipherText []byte) ([]byte, error) {
+	aead, err := cipher.NewAEAD(salt)
+	if err != nil {
+		return nil, err
+	}
+	if len(cipherText) < aead.Overhead() {
+		return nil, io.ErrUnexpectedEOF
+	}
+	if cap(plainText)-len(plainText) < len(cipherText)-aead.Overhead() {
+		return nil, io.ErrShortBuffer
+	}
+	return aead.Open(plainText, zeroNonce[:aead.NonceSize()], cipherText, nil)
+}

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -44,7 +44,7 @@ type aeadSpec struct {
 }
 
 // List of supported AEAD ciphers, as specified at https://shadowsocks.org/en/spec/AEAD-Ciphers.html
-var supportedAEADs = []aeadSpec{
+var supportedAEADs = [...]aeadSpec{
 	newAeadSpec("chacha20-ietf-poly1305", chacha20poly1305.New, chacha20poly1305.KeySize),
 	newAeadSpec("aes-256-gcm", newAesGCM, 32),
 	newAeadSpec("aes-192-gcm", newAesGCM, 24),

--- a/shadowsocks/cipher_test.go
+++ b/shadowsocks/cipher_test.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadowsocks
+
+import (
+	"testing"
+)
+
+func assertCipher(t *testing.T, name string, saltSize, tagSize int) {
+	cipher, err := NewCipher(name, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cipher.SaltSize() != saltSize || cipher.TagSize() != tagSize {
+		t.Fatalf("Bad spec for %v", name)
+	}
+}
+
+func TestSizes(t *testing.T) {
+	// Values from https://shadowsocks.org/en/spec/AEAD-Ciphers.html
+	assertCipher(t, "chacha20-ietf-poly1305", 32, 16)
+	assertCipher(t, "aes-256-gcm", 32, 16)
+	assertCipher(t, "aes-192-gcm", 24, 16)
+	assertCipher(t, "aes-128-gcm", 16, 16)
+}
+
+func TestUnsupportedCipher(t *testing.T) {
+	_, err := NewCipher("aes-256-cfb", "")
+	if err == nil {
+		t.Errorf("Should get an error for unsupported cipher")
+	}
+}
+
+func TestMaxNonceSize(t *testing.T) {
+	for _, aeadName := range SuportedCipherNames {
+		cipher, err := NewCipher(aeadName, "")
+		if err != nil {
+			t.Errorf("Failed to create Cipher %v: %v", aeadName, err)
+		}
+		aead, err := cipher.NewAEAD(make([]byte, cipher.SaltSize()))
+		if err != nil {
+			t.Errorf("Failed to create AEAD %v: %v", aeadName, err)
+		}
+		if aead.NonceSize() > len(zeroNonce) {
+			t.Errorf("Cipher %v has nonce size %v > zeroNonce (%v)", aeadName, aead.NonceSize(), len(zeroNonce))
+		}
+	}
+}

--- a/shadowsocks/cipher_test.go
+++ b/shadowsocks/cipher_test.go
@@ -44,7 +44,7 @@ func TestUnsupportedCipher(t *testing.T) {
 }
 
 func TestMaxNonceSize(t *testing.T) {
-	for _, aeadName := range SuportedCipherNames {
+	for _, aeadName := range SuportedCipherNames() {
 		cipher, err := NewCipher(aeadName, "")
 		if err != nil {
 			t.Errorf("Failed to create Cipher %v: %v", aeadName, err)

--- a/shadowsocks/cipher_test.go
+++ b/shadowsocks/cipher_test.go
@@ -44,7 +44,7 @@ func TestUnsupportedCipher(t *testing.T) {
 }
 
 func TestMaxNonceSize(t *testing.T) {
-	for _, aeadName := range SuportedCipherNames() {
+	for _, aeadName := range SupportedCipherNames() {
 		cipher, err := NewCipher(aeadName, "")
 		if err != nil {
 			t.Errorf("Failed to create Cipher %v: %v", aeadName, err)

--- a/shadowsocks/stream_test.go
+++ b/shadowsocks/stream_test.go
@@ -10,13 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shadowsocks/go-shadowsocks2/shadowaead"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-func newTestCipher(t *testing.T) shadowaead.Cipher {
-	key := []byte("12345678901234567890123456789012") // 32 bytes
-	cipher, err := shadowaead.Chacha20Poly1305(key)
+func newTestCipher(t *testing.T) *Cipher {
+	cipher, err := NewCipher("chacha20-ietf-poly1305", "test secret")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,9 +61,9 @@ func TestCipherReaderEOF(t *testing.T) {
 	}
 }
 
-func encryptBlocks(cipher shadowaead.Cipher, salt []byte, blocks [][]byte) (io.Reader, error) {
+func encryptBlocks(cipher *Cipher, salt []byte, blocks [][]byte) (io.Reader, error) {
 	var ssText bytes.Buffer
-	aead, err := cipher.Encrypter(salt)
+	aead, err := cipher.NewAEAD(salt)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create AEAD: %v", err)
 	}


### PR DESCRIPTION
This PR removes all the dependencies on `shadowaead.Cipher`. Now the only dependency on go-shadowsocks2 is the `socks` library.

As I introduce a `cipher` library, I provide a way to list the supported ciphers, allowing us to assert compatibility for the TCP trial size and the max nonce size in the tests, rather than at runtime. This cleans up the `CipherList` code.

I also provide a way to get the tag size directly from the cipher object, removing the need to create an AEAD object. This simplifies some pieces of the code.