### PR TITLE
Reduce memory usage in read streams

### DIFF
--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -77,7 +77,7 @@ func newAesGCM(key []byte) (cipher.AEAD, error) {
 	return cipher.NewGCM(blk)
 }
 
-func maxCipherOverhead() int {
+func maxTagSize() int {
 	max := 0
 	for _, spec := range supportedAEADs {
 		if spec.tagSize > max {

--- a/shadowsocks/cipher.go
+++ b/shadowsocks/cipher.go
@@ -77,6 +77,16 @@ func newAesGCM(key []byte) (cipher.AEAD, error) {
 	return cipher.NewGCM(blk)
 }
 
+func maxCipherOverhead() int {
+	max := 0
+	for _, spec := range supportedAEADs {
+		if spec.tagSize > max {
+			max = spec.tagSize
+		}
+	}
+	return max
+}
+
 // Cipher encapsulates a Shadowsocks AEAD spec and a secret
 type Cipher struct {
 	aead   aeadSpec

--- a/shadowsocks/stream.go
+++ b/shadowsocks/stream.go
@@ -21,10 +21,19 @@ import (
 	"fmt"
 	"io"
 	"sync"
+
+	"github.com/Jigsaw-Code/outline-ss-server/slicepool"
 )
 
 // payloadSizeMask is the maximum size of payload in bytes.
 const payloadSizeMask = 0x3FFF // 16*1024 - 1
+
+// Maximum allowed cipher overhead
+const maxCipherOverhead = 16
+
+// Buffer pool used for encrypting and decrypting Shadowsocks streams.
+// The largest buffer we could need is for encrypting a max-length payload.
+var ssPool = slicepool.MakePool(payloadSizeMask + maxCipherOverhead)
 
 // Writer is an io.Writer that also implements io.ReaderFrom to
 // allow for piping the data without extra allocations and copies.
@@ -262,7 +271,10 @@ type chunkReader struct {
 	aead cipher.AEAD
 	// Index of the next encrypted chunk to read.
 	counter []byte
-	buf     []byte
+	// Buffer for the uint16 size and its AEAD tag.  Made in init().
+	size []byte
+	// Holds a buffer for the payload and its AEAD tag, when needed.
+	payload slicepool.Slice
 }
 
 // Reader is an io.Reader that also implements io.WriterTo to
@@ -276,7 +288,11 @@ type Reader interface {
 // the shadowsocks protocol with the given shadowsocks cipher.
 func NewShadowsocksReader(reader io.Reader, ssCipher *Cipher) Reader {
 	return &readConverter{
-		cr: &chunkReader{reader: reader, ssCipher: ssCipher},
+		cr: &chunkReader{
+			reader:   reader,
+			ssCipher: ssCipher,
+			payload:  ssPool.Slice(),
+		},
 	}
 }
 
@@ -295,8 +311,11 @@ func (cr *chunkReader) init() (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to create AEAD: %v", err)
 		}
+		if cr.aead.Overhead() > maxCipherOverhead {
+			return fmt.Errorf("Excessive cipher overhead (%d)", cr.aead.Overhead())
+		}
 		cr.counter = make([]byte, cr.aead.NonceSize())
-		cr.buf = make([]byte, payloadSizeMask+cr.aead.Overhead())
+		cr.size = make([]byte, 2+cr.aead.Overhead())
 	}
 	return nil
 }
@@ -318,31 +337,38 @@ func (cr *chunkReader) readMessage(buf []byte) error {
 	return nil
 }
 
+// ReadChunk returns the next chunk from the stream.  Callers must fully
+// consume and discard the previous chunk before calling ReadChunk again.
 func (cr *chunkReader) ReadChunk() ([]byte, error) {
 	if err := cr.init(); err != nil {
 		return nil, err
 	}
+
+	// Release the previous payload buffer.
+	cr.payload.Release()
+
 	// In Shadowsocks-AEAD, each chunk consists of two
 	// encrypted messages.  The first message contains the payload length,
-	// and the second message is the payload.
-	sizeBuf := cr.buf[:2+cr.aead.Overhead()]
-	if err := cr.readMessage(sizeBuf); err != nil {
+	// and the second message is the payload.  Idle read threads will
+	// block here until the next chunk.
+	if err := cr.readMessage(cr.size); err != nil {
 		if err != io.EOF && err != io.ErrUnexpectedEOF {
 			err = fmt.Errorf("failed to read payload size: %v", err)
 		}
 		return nil, err
 	}
-	size := int(binary.BigEndian.Uint16(sizeBuf) & payloadSizeMask)
+	size := int(binary.BigEndian.Uint16(cr.size) & payloadSizeMask)
 	sizeWithTag := size + cr.aead.Overhead()
-	if cap(cr.buf) < sizeWithTag {
-		// This code is unreachable.
+	payloadBuf := cr.payload.Acquire()
+	if cap(payloadBuf) < sizeWithTag {
+		// This code is unreachable if the constants are set correctly.
 		return nil, io.ErrShortBuffer
 	}
-	payloadBuf := cr.buf[:sizeWithTag]
-	if err := cr.readMessage(payloadBuf); err != nil {
+	if err := cr.readMessage(payloadBuf[:sizeWithTag]); err != nil {
 		if err == io.EOF { // EOF is not expected mid-chunk.
 			err = io.ErrUnexpectedEOF
 		}
+		cr.payload.Release()
 		return nil, err
 	}
 	return payloadBuf[:size], nil
@@ -388,6 +414,7 @@ func (c *readConverter) ensureLeftover() error {
 	if len(c.leftover) > 0 {
 		return nil
 	}
+	c.leftover = nil
 	payload, err := c.cr.ReadChunk()
 	if err != nil {
 		return err

--- a/shadowsocks/stream.go
+++ b/shadowsocks/stream.go
@@ -28,12 +28,9 @@ import (
 // payloadSizeMask is the maximum size of payload in bytes.
 const payloadSizeMask = 0x3FFF // 16*1024 - 1
 
-// Maximum allowed cipher overhead
-const maxCipherOverhead = 16
-
 // Buffer pool used for encrypting and decrypting Shadowsocks streams.
 // The largest buffer we could need is for encrypting a max-length payload.
-var ssPool = slicepool.MakePool(payloadSizeMask + maxCipherOverhead)
+var ssPool = slicepool.MakePool(payloadSizeMask + maxCipherOverhead())
 
 // Writer is an io.Writer that also implements io.ReaderFrom to
 // allow for piping the data without extra allocations and copies.
@@ -310,9 +307,6 @@ func (cr *chunkReader) init() (err error) {
 		cr.aead, err = cr.ssCipher.NewAEAD(salt)
 		if err != nil {
 			return fmt.Errorf("failed to create AEAD: %v", err)
-		}
-		if cr.aead.Overhead() > maxCipherOverhead {
-			return fmt.Errorf("Excessive cipher overhead (%d)", cr.aead.Overhead())
 		}
 		cr.counter = make([]byte, cr.aead.NonceSize())
 		cr.size = make([]byte, 2+cr.aead.Overhead())

--- a/shadowsocks/stream.go
+++ b/shadowsocks/stream.go
@@ -28,9 +28,9 @@ import (
 // payloadSizeMask is the maximum size of payload in bytes.
 const payloadSizeMask = 0x3FFF // 16*1024 - 1
 
-// Buffer pool used for encrypting and decrypting Shadowsocks streams.
-// The largest buffer we could need is for encrypting a max-length payload.
-var ssPool = slicepool.MakePool(payloadSizeMask + maxTagSize())
+// Buffer pool used for decrypting Shadowsocks streams.
+// The largest buffer we could need is for decrypting a max-length payload.
+var readBufPool = slicepool.MakePool(payloadSizeMask + maxTagSize())
 
 // Writer is an io.Writer that also implements io.ReaderFrom to
 // allow for piping the data without extra allocations and copies.
@@ -288,7 +288,7 @@ func NewShadowsocksReader(reader io.Reader, ssCipher *Cipher) Reader {
 		cr: &chunkReader{
 			reader:   reader,
 			ssCipher: ssCipher,
-			payload:  ssPool.LazySlice(),
+			payload:  readBufPool.LazySlice(),
 		},
 	}
 }


### PR DESCRIPTION
This change avoids allocating a 16KB buffer for every Shadowsocks
Reader.  Instead, the open streams share a pool of buffers,
allocating only as many as are needed, i.e. the number of streams that
currently have data queued for reading.  Most streams are expected
to be idle most of the time, so this should reduce peak memory
requirements on heavily loaded servers and memory-constrained
clients.

The benchmarks confirm that this change does not increase the number of
allocations, and can sometimes lower it:

Master:
```
BenchmarkTCPThroughput-4    78934     16120 ns/op  496 mbps   0 B/op    0 allocs/op
BenchmarkTCPMultiplexing-4   4668    247983 ns/op        121949 B/op  682 allocs/op
```

This branch:
```
BenchmarkTCPThroughput-4    68811     16135 ns/op  496 mbps   0 B/op    0 allocs/op
BenchmarkTCPMultiplexing-    5200    256331 ns/op         86646 B/op  668 allocs/op
```

With an instrumented build on Android, the number of open reads easily
climbed over 200 while browsing, but the number of outstanding buffers
was always below 20, for a savings of ~3 MB.