### PR TITLE
Reduce cost of shadowsocks_data_bytes and shadowsocks_tcp_probes_bucket metrics

### DIFF
--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -116,7 +116,7 @@ func newShadowsocksMetrics(ipCountryDB *geoip2.Reader) *shadowsocksMetrics {
 				Namespace: "shadowsocks",
 				Name:      "data_bytes",
 				Help:      "Bytes transferred by the proxy",
-			}, []string{"dir", "proto", "location", "access_key"}),
+			}, []string{"dir", "proto", "location", "status", "access_key"}),
 		tcpProbes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "shadowsocks",
 			Name:      "tcp_probes",
@@ -226,10 +226,10 @@ func (m *shadowsocksMetrics) AddClosedTCPConnection(clientLocation, accessKey, s
 	m.tcpClosedConnections.WithLabelValues(clientLocation, status, accessKey).Inc()
 	m.tcpConnectionDurationMs.WithLabelValues(status).Observe(duration.Seconds() * 1000)
 	m.timeToCipherMs.WithLabelValues("tcp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, accessKey), data.ClientProxy)
-	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, accessKey), data.ProxyTarget)
-	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, accessKey), data.TargetProxy)
-	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, accessKey), data.ProxyClient)
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, status, accessKey), data.ClientProxy)
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, status, accessKey), data.ProxyTarget)
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, status, accessKey), data.TargetProxy)
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, status, accessKey), data.ProxyClient)
 }
 
 func (m *shadowsocksMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data ProxyMetrics) {
@@ -238,13 +238,13 @@ func (m *shadowsocksMetrics) AddTCPProbe(clientLocation, status, drainResult str
 
 func (m *shadowsocksMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
 	m.timeToCipherMs.WithLabelValues("udp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, accessKey), int64(clientProxyBytes))
-	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, accessKey), int64(proxyTargetBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, status, accessKey), int64(clientProxyBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, status, accessKey), int64(proxyTargetBytes))
 }
 
 func (m *shadowsocksMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
-	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, accessKey), int64(targetProxyBytes))
-	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, accessKey), int64(proxyClientBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, status, accessKey), int64(targetProxyBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, status, accessKey), int64(proxyClientBytes))
 }
 
 func (m *shadowsocksMetrics) AddUDPNatEntry() {

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -216,9 +216,9 @@ func isFound(accessKey string) string {
 }
 
 // addIfNonZero helps avoid the creation of series that are always zero.
-func addIfNonZero(counter prometheus.Counter, value int64) {
+func addIfNonZero(counter prometheus.Counter, value float64) {
 	if value > 0 {
-		counter.Add(float64(value))
+		counter.Add(value)
 	}
 }
 
@@ -226,25 +226,25 @@ func (m *shadowsocksMetrics) AddClosedTCPConnection(clientLocation, accessKey, s
 	m.tcpClosedConnections.WithLabelValues(clientLocation, status, accessKey).Inc()
 	m.tcpConnectionDurationMs.WithLabelValues(status).Observe(duration.Seconds() * 1000)
 	m.timeToCipherMs.WithLabelValues("tcp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, accessKey), data.ClientProxy)
-	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, accessKey), data.ProxyTarget)
-	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, accessKey), data.TargetProxy)
-	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, accessKey), data.ProxyClient)
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, accessKey), float64(data.ClientProxy))
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, accessKey), float64(data.ProxyTarget))
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, accessKey), float64(data.TargetProxy))
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, accessKey), float64(data.ProxyClient))
 }
 
 func (m *shadowsocksMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data ProxyMetrics) {
 	m.tcpProbes.WithLabelValues(clientLocation, strconv.Itoa(port), status, drainResult).Observe(float64(data.ClientProxy))
 }
 
-func (m *shadowsocksMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int64, timeToCipher time.Duration) {
+func (m *shadowsocksMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
 	m.timeToCipherMs.WithLabelValues("udp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, accessKey), clientProxyBytes)
-	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, accessKey), proxyTargetBytes)
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, accessKey), float64(clientProxyBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, accessKey), float64(proxyTargetBytes))
 }
 
-func (m *shadowsocksMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int64) {
-	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, accessKey), targetProxyBytes)
-	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, accessKey), proxyClientBytes)
+func (m *shadowsocksMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, accessKey), float64(targetProxyBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, accessKey), float64(proxyClientBytes))
 }
 
 func (m *shadowsocksMetrics) AddUDPNatEntry() {

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -216,9 +216,9 @@ func isFound(accessKey string) string {
 }
 
 // addIfNonZero helps avoid the creation of series that are always zero.
-func addIfNonZero(counter prometheus.Counter, value float64) {
+func addIfNonZero(counter prometheus.Counter, value int64) {
 	if value > 0 {
-		counter.Add(value)
+		counter.Add(float64(value))
 	}
 }
 
@@ -226,10 +226,10 @@ func (m *shadowsocksMetrics) AddClosedTCPConnection(clientLocation, accessKey, s
 	m.tcpClosedConnections.WithLabelValues(clientLocation, status, accessKey).Inc()
 	m.tcpConnectionDurationMs.WithLabelValues(status).Observe(duration.Seconds() * 1000)
 	m.timeToCipherMs.WithLabelValues("tcp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, accessKey), float64(data.ClientProxy))
-	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, accessKey), float64(data.ProxyTarget))
-	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, accessKey), float64(data.TargetProxy))
-	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, accessKey), float64(data.ProxyClient))
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, accessKey), data.ClientProxy)
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, accessKey), data.ProxyTarget)
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, accessKey), data.TargetProxy)
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, accessKey), data.ProxyClient)
 }
 
 func (m *shadowsocksMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data ProxyMetrics) {
@@ -238,13 +238,13 @@ func (m *shadowsocksMetrics) AddTCPProbe(clientLocation, status, drainResult str
 
 func (m *shadowsocksMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
 	m.timeToCipherMs.WithLabelValues("udp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, accessKey), float64(clientProxyBytes))
-	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, accessKey), float64(proxyTargetBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, accessKey), int64(clientProxyBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, accessKey), int64(proxyTargetBytes))
 }
 
 func (m *shadowsocksMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
-	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, accessKey), float64(targetProxyBytes))
-	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, accessKey), float64(proxyClientBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, accessKey), int64(targetProxyBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, accessKey), int64(proxyClientBytes))
 }
 
 func (m *shadowsocksMetrics) AddUDPNatEntry() {

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -120,7 +120,7 @@ func newShadowsocksMetrics(ipCountryDB *geoip2.Reader) *shadowsocksMetrics {
 		tcpProbes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "shadowsocks",
 			Name:      "tcp_probes",
-			Buckets:   []float64{0, 48, 49, 50, 51, 52, 72, 73, 90, 91, 220, 221},
+			Buckets:   []float64{0, 49, 50, 51, 73, 91},
 			Help:      "Histogram of number of bytes from client to proxy, for detecting possible probes",
 		}, []string{"location", "port", "status", "error"}),
 		timeToCipherMs: prometheus.NewHistogramVec(

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -116,7 +116,7 @@ func newShadowsocksMetrics(ipCountryDB *geoip2.Reader) *shadowsocksMetrics {
 				Namespace: "shadowsocks",
 				Name:      "data_bytes",
 				Help:      "Bytes transferred by the proxy",
-			}, []string{"dir", "proto", "location", "status", "access_key"}),
+			}, []string{"dir", "proto", "location", "access_key"}),
 		tcpProbes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "shadowsocks",
 			Name:      "tcp_probes",
@@ -215,29 +215,36 @@ func isFound(accessKey string) string {
 	return fmt.Sprintf("%t", accessKey != "")
 }
 
+// addIfNonZero helps avoid the creation of series that are always zero.
+func addIfNonZero(counter prometheus.Counter, value int64) {
+	if value > 0 {
+		counter.Add(float64(value))
+	}
+}
+
 func (m *shadowsocksMetrics) AddClosedTCPConnection(clientLocation, accessKey, status string, data ProxyMetrics, timeToCipher, duration time.Duration) {
 	m.tcpClosedConnections.WithLabelValues(clientLocation, status, accessKey).Inc()
 	m.tcpConnectionDurationMs.WithLabelValues(status).Observe(duration.Seconds() * 1000)
 	m.timeToCipherMs.WithLabelValues("tcp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, status, accessKey).Add(float64(data.ClientProxy))
-	m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, status, accessKey).Add(float64(data.ProxyTarget))
-	m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, status, accessKey).Add(float64(data.TargetProxy))
-	m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, status, accessKey).Add(float64(data.ProxyClient))
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "tcp", clientLocation, accessKey), data.ClientProxy)
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "tcp", clientLocation, accessKey), data.ProxyTarget)
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "tcp", clientLocation, accessKey), data.TargetProxy)
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "tcp", clientLocation, accessKey), data.ProxyClient)
 }
 
 func (m *shadowsocksMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data ProxyMetrics) {
 	m.tcpProbes.WithLabelValues(clientLocation, strconv.Itoa(port), status, drainResult).Observe(float64(data.ClientProxy))
 }
 
-func (m *shadowsocksMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
+func (m *shadowsocksMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int64, timeToCipher time.Duration) {
 	m.timeToCipherMs.WithLabelValues("udp", isFound(accessKey)).Observe(timeToCipher.Seconds() * 1000)
-	m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, status, accessKey).Add(float64(clientProxyBytes))
-	m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, status, accessKey).Add(float64(proxyTargetBytes))
+	addIfNonZero(m.dataBytes.WithLabelValues("c>p", "udp", clientLocation, accessKey), clientProxyBytes)
+	addIfNonZero(m.dataBytes.WithLabelValues("p>t", "udp", clientLocation, accessKey), proxyTargetBytes)
 }
 
-func (m *shadowsocksMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
-	m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, status, accessKey).Add(float64(targetProxyBytes))
-	m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, status, accessKey).Add(float64(proxyClientBytes))
+func (m *shadowsocksMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int64) {
+	addIfNonZero(m.dataBytes.WithLabelValues("p<t", "udp", clientLocation, accessKey), targetProxyBytes)
+	addIfNonZero(m.dataBytes.WithLabelValues("c<p", "udp", clientLocation, accessKey), proxyClientBytes)
 }
 
 func (m *shadowsocksMetrics) AddUDPNatEntry() {


### PR DESCRIPTION
`shadowsocks_data_bytes` is dominated by cipher errors from all different countries, which end up with a series for each direction, even though 3 of them are always zero. This change will reduce the cost of the cipher error series to 1/4.
As an example, on a server of mine, I have 235 shadowsocks_data_bytes series, but only 85 with non-zero series. If we restrict to ERR_CIPHER, there are 182 series, only 44 of those are non-zero.

I also realized that `shadowsocks_tcp_probes_bucket` takes a lot of space. On the same server, I had 1023 probe bucket series.
I'm afraid my previous (unreleased) change to the buckets will significantly increase the memory usage, so I'm changing it back to 7 buckets.