### PR TITLE
Bugfix: track the keyID for UDP connections

### DIFF
--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -89,10 +89,16 @@ func (conn *fakePacketConn) Close() error {
 	return nil
 }
 
+type udpReport struct {
+	clientLocation, accessKey, status  string
+	clientProxyBytes, proxyTargetBytes int
+}
+
 // Stub metrics implementation for testing NAT behaviors.
 type natTestMetrics struct {
 	metrics.ShadowsocksMetrics
 	natEntriesAdded int
+	upstreamPackets []udpReport
 }
 
 func (m *natTestMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data metrics.ProxyMetrics) {
@@ -107,6 +113,7 @@ func (m *natTestMetrics) SetNumAccessKeys(numKeys int, numPorts int) {
 func (m *natTestMetrics) AddOpenTCPConnection(clientLocation string) {
 }
 func (m *natTestMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
+	m.upstreamPackets = append(m.upstreamPackets, udpReport{clientLocation, accessKey, status, clientProxyBytes, proxyTargetBytes})
 }
 func (m *natTestMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
 }
@@ -115,21 +122,20 @@ func (m *natTestMetrics) AddUDPNatEntry() {
 }
 func (m *natTestMetrics) RemoveUDPNatEntry() {}
 
-func TestIPFilter(t *testing.T) {
-	// Takes a validation policy, and returns the metrics it
-	// generates when localhost access is attempted
-	checkLocalhost := func(validator onet.TargetIPValidator) *natTestMetrics {
-		ciphers, _ := MakeTestCiphers([]string{"asdf"})
-		cipher := ciphers.SnapshotForClientIP(nil)[0].Value.(*CipherEntry).Cipher
-		clientConn := makePacketConn()
-		metrics := &natTestMetrics{}
-		service := NewUDPService(timeout, ciphers, metrics)
-		service.SetTargetIPValidator(validator)
-		go service.Serve(clientConn)
+// Takes a validation policy, and returns the metrics it
+// generates when localhost access is attempted
+func sendToDiscard(payloads [][]byte, validator onet.TargetIPValidator) *natTestMetrics {
+	ciphers, _ := MakeTestCiphers([]string{"asdf"})
+	cipher := ciphers.SnapshotForClientIP(nil)[0].Value.(*CipherEntry).Cipher
+	clientConn := makePacketConn()
+	metrics := &natTestMetrics{}
+	service := NewUDPService(timeout, ciphers, metrics)
+	service.SetTargetIPValidator(validator)
+	go service.Serve(clientConn)
 
-		// Send one packet to the "discard" port on localhost
-		targetAddr := socks.ParseAddr("127.0.0.1:9")
-		payload := []byte("payload")
+	// Send one packet to the "discard" port on localhost
+	targetAddr := socks.ParseAddr("127.0.0.1:9")
+	for _, payload := range payloads {
 		plaintext := append(targetAddr, payload...)
 		ciphertext := make([]byte, cipher.SaltSize()+len(plaintext)+cipher.TagSize())
 		ss.Pack(ciphertext, plaintext, cipher)
@@ -140,24 +146,72 @@ func TestIPFilter(t *testing.T) {
 			},
 			payload: ciphertext,
 		}
-
-		service.GracefulStop()
-		return metrics
 	}
 
+	service.GracefulStop()
+	return metrics
+}
+
+func TestIPFilter(t *testing.T) {
+	// Test both the first-packet and subsequent-packet cases.
+	payloads := [][]byte{[]byte("payload1"), []byte("payload2")}
+
 	t.Run("Localhost allowed", func(t *testing.T) {
-		metrics := checkLocalhost(allowAll)
+		metrics := sendToDiscard(payloads, allowAll)
 		if metrics.natEntriesAdded != 1 {
 			t.Errorf("Expected 1 NAT entry, not %d", metrics.natEntriesAdded)
 		}
 	})
 
 	t.Run("Localhost not allowed", func(t *testing.T) {
-		metrics := checkLocalhost(onet.RequirePublicIP)
+		metrics := sendToDiscard(payloads, onet.RequirePublicIP)
 		if metrics.natEntriesAdded != 0 {
 			t.Error("Unexpected NAT entry on rejected packet")
 		}
+		if len(metrics.upstreamPackets) != 2 {
+			t.Errorf("Expected 2 reports, not %v", metrics.upstreamPackets)
+		}
+		for _, report := range metrics.upstreamPackets {
+			if report.clientProxyBytes == 0 {
+				t.Error("Expected nonzero input packet size")
+			}
+			if report.proxyTargetBytes != 0 {
+				t.Error("No bytes should be sent due to a disallowed packet")
+			}
+			if report.accessKey != "id-0" {
+				t.Errorf("Unexpected access key: %s", report.accessKey)
+			}
+		}
 	})
+}
+
+func TestUpstreamMetrics(t *testing.T) {
+	// Test both the first-packet and subsequent-packet cases.
+	const N = 10
+	payloads := make([][]byte, 0)
+	for i := 1; i <= N; i++ {
+		payloads = append(payloads, make([]byte, i))
+	}
+
+	metrics := sendToDiscard(payloads, allowAll)
+
+	if len(metrics.upstreamPackets) != N {
+		t.Errorf("Expected %d reports, not %v", N, metrics.upstreamPackets)
+	}
+	for i, report := range metrics.upstreamPackets {
+		if report.proxyTargetBytes != i+1 {
+			t.Errorf("Expected %d payload bytes, not %d", i, report.proxyTargetBytes)
+		}
+		if report.clientProxyBytes <= report.proxyTargetBytes {
+			t.Errorf("Expected nonzero input overhead (%d > %d)", report.clientProxyBytes, report.proxyTargetBytes)
+		}
+		if report.accessKey != "id-0" {
+			t.Errorf("Unexpected access key name: %s", report.accessKey)
+		}
+		if report.status != "OK" {
+			t.Errorf("Wrong status: %s", report.status)
+		}
+	}
 }
 
 func assertAlmostEqual(t *testing.T, a, b time.Time) {


### PR DESCRIPTION
This is important for applying usage limits to UDP streams.  It also
fixes a bug in metrics reporting, because the shared metrics are not
tolerant of proxy<->target traffic that lacks a keyID.