### PR TITLE
Happy Eyeballs and fallback for the proxy hostname

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: go
 
 go:
-- "1.14"
+- "1.15"
 - "stable"
 
 script:

--- a/client/client.go
+++ b/client/client.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"time"
 
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
-	"github.com/Jigsaw-Code/outline-ss-server/net/ipset"
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
 	"github.com/Jigsaw-Code/outline-ss-server/slicepool"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
@@ -37,25 +35,23 @@ type Client interface {
 // `host:port`, with authentication parameters `cipher` (AEAD) and `password`.
 // TODO: add a dialer argument to support proxy chaining and transport changes.
 func NewClient(host string, port int, password, cipherName string) (Client, error) {
+	// If `host` is a domain name, the client resolves it here to provide clearer
+	// error reporting and simplify UDP forwarding.  If these IPs all stop working,
+	// any TCP connection will re-resolve the name and add a working IP to the set.
+	dialer, err := makeDialer(host, port)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to resolve proxy address: %v", err)
+	}
 	cipher, err := ss.NewCipher(cipherName, password)
 	if err != nil {
 		return nil, err
 	}
-	d := ssClient{proxyHost: host, proxyPort: port, cipher: cipher}
-	// If `host` is a domain name, the client resolves it here to provide clearer
-	// error reporting and simplify UDP forwarding.  If these IPs all stop working,
-	// any TCP connection will re-resolve the name and add a working IP to the set.
-	if err := d.ips.Add(host); err != nil {
-		return nil, fmt.Errorf("Failed to resolve proxy address: %v", err)
-	}
-	return &d, nil
+	return &ssClient{dialer, cipher}, nil
 }
 
 type ssClient struct {
-	proxyHost string
-	proxyPort int
-	cipher    *ss.Cipher
-	ips       ipset.IPSet
+	dialer *dialer
+	cipher *ss.Cipher
 }
 
 // This code contains an optimization to send the initial client payload along with
@@ -75,7 +71,7 @@ func (c *ssClient) DialTCP(laddr *net.TCPAddr, raddr string) (onet.DuplexConn, e
 	if socksTargetAddr == nil {
 		return nil, errors.New("Failed to parse target address")
 	}
-	proxyConn, err := c.dialProxy(laddr)
+	proxyConn, monitor, err := c.dialer.DialTCP()
 	if err != nil {
 		return nil, err
 	}
@@ -89,31 +85,8 @@ func (c *ssClient) DialTCP(laddr *net.TCPAddr, raddr string) (onet.DuplexConn, e
 		ssw.Flush()
 	})
 	ssr := ss.NewShadowsocksReader(proxyConn, c.cipher)
-	return onet.WrapConn(proxyConn, ssr, ssw), nil
-}
-
-func (c *ssClient) dialProxy(laddr *net.TCPAddr) (*net.TCPConn, error) {
-	if confirmedIP := c.ips.Confirmed(); confirmedIP != nil {
-		// Use a known-working IP address for the proxy.
-		proxyAddr := &net.TCPAddr{IP: confirmedIP, Port: c.proxyPort}
-		proxyConn, err := net.DialTCP("tcp", laddr, proxyAddr)
-		if err != nil {
-			c.ips.Disconfirm(confirmedIP)
-		}
-		return proxyConn, err
-	}
-	// Use Go's built-in fallback and Happy Eyeballs logic to identify a working
-	// address.  This will cause redundant DNS queries on a fresh client until an
-	// IP is confirmed, but most OSes have a built-in DNS cache so that should not
-	// be too expensive.
-	// Note: laddr is ignored.  TODO: Remove laddr from the arguments.
-	proxyAddr := net.JoinHostPort(c.proxyHost, strconv.Itoa(c.proxyPort))
-	proxyConn, err := net.Dial("tcp", proxyAddr)
-	if err != nil {
-		return nil, err
-	}
-	c.ips.AddAndConfirm(proxyConn.RemoteAddr().(*net.TCPAddr).IP)
-	return proxyConn.(*net.TCPConn), nil
+	ssConn := onet.WrapConn(proxyConn, ssr, ssw)
+	return onet.MonitorConn(ssConn, monitor), nil
 }
 
 func (c *ssClient) ListenUDP(laddr *net.UDPAddr) (net.PacketConn, error) {
@@ -148,39 +121,8 @@ func (c *packetConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := c.send(buf); err != nil {
-		return 0, err
-	}
-	return len(b), nil
-}
-
-func (c *packetConn) send(buf []byte) error {
-	var ips []net.IP
-	if confirmedIP := c.client.ips.Confirmed(); confirmedIP != nil {
-		ips = []net.IP{confirmedIP}
-	} else {
-		// GetAll returns the IPs in shuffled order, so each packet will try
-		// a different IP at random until an IP is confirmed working.
-		ips = c.client.ips.GetAll()
-		if len(ips) == 0 {
-			// If LookupIPAddr never returns ({}, nil), this is unreachable.
-			return errors.New("No IPs for the proxy")
-		}
-	}
-
-	// This loop's main purpose is to skip IPv6 addresses on v4-only clients.
-	var err error
-	proxyAddr := net.UDPAddr{Port: c.client.proxyPort}
-	for _, proxyAddr.IP = range ips {
-		_, err = c.UDPConn.WriteToUDP(buf, &proxyAddr)
-		if err == nil {
-			return nil
-		}
-		// A confirmed address could become non-routable if the IPv6
-		// network interface is disconnected.
-		c.client.ips.Disconfirm(proxyAddr.IP)
-	}
-	return err
+	err = c.client.dialer.UDPWrite(c.UDPConn, buf)
+	return len(b), err
 }
 
 // ReadFrom reads from the embedded PacketConn and decrypts into `b`.
@@ -206,7 +148,7 @@ func (c *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	if len(b) < len(buf)-len(socksSrcAddr) {
 		return n, srcAddr, io.ErrShortBuffer
 	}
-	c.client.ips.Confirm(proxyAddr.IP)
+	c.client.dialer.IPs.Confirm(proxyAddr.IP)
 	return n, srcAddr, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ var udpPool = slicepool.MakePool(clientUDPBufferSize)
 // Client is a client for Shadowsocks TCP and UDP connections.
 type Client interface {
 	// DialTCP connects to `raddr` over TCP though a Shadowsocks proxy.
-	// `laddr` is a local bind address, a local address is automatically chosen if nil.
+	// `laddr` is ignored.  TODO: Remove laddr.
 	// `raddr` has the form `host:port`, where `host` can be a domain name or IP address.
 	DialTCP(laddr *net.TCPAddr, raddr string) (onet.DuplexConn, error)
 

--- a/client/dial.go
+++ b/client/dial.go
@@ -1,0 +1,131 @@
+// Copyright 2021 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strconv"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+	"github.com/Jigsaw-Code/outline-ss-server/net/ipset"
+)
+
+// This dialer handles refreshing, confirming, and disconfirming proxy IPs.
+// It implements a heuristic state machine: an IP is confirmed when a signal
+// indicates that it is working correctly, and disconfimed when a signal
+// suggests that it is not.  When an IP is confirmed, all subsequent TCP
+// sockets and UDP packets will flow only to that IP.  Otherwise, TCP sockets
+// will use standard hostname-based connection, and UDP packets will try
+// known IPs at random.
+type dialer struct {
+	host string
+	port int
+	IPs  ipset.IPSet
+}
+
+func makeDialer(host string, port int) (*dialer, error) {
+	d := &dialer{host: host, port: port}
+	if err := d.IPs.Add(host); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// DialTCP connects to the dialer's host and port, using a confirmed IP from
+// `ips` if possible.  It will disconfirm failing IPs.  The returned ConnMonitor
+// can be applied to the decrypted channel to confirm the IP if it appears to be
+// working well, or disconfirm if a post-handshake error occurs.
+func (d *dialer) DialTCP() (*net.TCPConn, onet.ConnMonitor, error) {
+	if confirmedIP := d.IPs.Confirmed(); confirmedIP != nil {
+		// Use a known-working IP address for the proxy.
+		proxyAddr := &net.TCPAddr{IP: confirmedIP, Port: d.port}
+		proxyConn, err := net.DialTCP("tcp", nil, proxyAddr)
+		if err == nil {
+			return proxyConn, &connMonitor{ip: confirmedIP, ips: &d.IPs}, nil
+		}
+		d.IPs.Disconfirm(confirmedIP)
+	}
+	// Use Go's built-in fallback and Happy Eyeballs logic to identify a working
+	// address.  This will cause redundant DNS queries on a fresh client until an
+	// IP is confirmed, but most OSes have a built-in DNS cache so that should not
+	// be too expensive.
+	proxyAddr := net.JoinHostPort(d.host, strconv.Itoa(d.port))
+	proxyConn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		return nil, nil, err
+	}
+	proxyIP := proxyConn.RemoteAddr().(*net.TCPAddr).IP
+	monitor := &connMonitor{ip: proxyIP, ips: &d.IPs}
+	return proxyConn.(*net.TCPConn), monitor, nil
+}
+
+// UDPWrite uses `conn` to send `buf` to `port` on a routable IP from `ips`.
+// Non-routable addresses will be disconfirmed.  The caller can confirm the
+// IP if valid replies are received.
+func (d *dialer) UDPWrite(conn *net.UDPConn, buf []byte) error {
+	addr := net.UDPAddr{IP: d.IPs.Confirmed(), Port: d.port}
+	if addr.IP != nil {
+		if _, err := conn.WriteToUDP(buf, &addr); err == nil {
+			return nil
+		}
+		// A confirmed address could become non-routable if the IPv6
+		// network interface is disconnected.
+		d.IPs.Disconfirm(addr.IP)
+	}
+
+	// This loop's main purpose is to skip IPv6 addresses on v4-only clients.
+	err := errors.New("IPSet is empty")
+	for _, addr.IP = range d.IPs.GetAll() {
+		_, err = conn.WriteToUDP(buf, &addr)
+		if err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+type connMonitor struct {
+	confirmed bool
+	ip        net.IP // Remote IP of the monitored connection
+	ips       *ipset.IPSet
+}
+
+func (m *connMonitor) OnRead(n int64, err error) {
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			if m.confirmed {
+				// Reconfirm on clean shutdown after successful download.
+				m.ips.AddAndConfirm(m.ip)
+			}
+		} else if !errors.Is(err, os.ErrDeadlineExceeded) {
+			// Unclean shutdown (timeout or reset).
+			m.ips.Disconfirm(m.ip)
+		}
+	} else if n > 0 && !m.confirmed {
+		// Confirm on the first successful read.
+		m.ips.AddAndConfirm(m.ip)
+		m.confirmed = true
+	}
+}
+
+func (m *connMonitor) OnWrite(n int64, err error) {
+	if err != nil && !errors.Is(err, io.EOF) &&
+		!errors.Is(err, os.ErrDeadlineExceeded) {
+		m.ips.Disconfirm(m.ip)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-go 1.14
+go 1.15

--- a/net/ipset/ipset.go
+++ b/net/ipset/ipset.go
@@ -1,0 +1,135 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipset
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"sync"
+)
+
+// IPSet represents an unordered collection of IP addresses for a single host.
+// One IP can be marked as confirmed to be working correctly.
+type IPSet struct {
+	mu        sync.RWMutex
+	ips       []net.IP      // All known IPs for the server.
+	confirmed net.IP        // IP address confirmed to be working
+	r         *net.Resolver // Resolver to use for hostname resolution
+}
+
+// SetResolver allows use of a custom resolver for IPSet.Add().
+func (s *IPSet) SetResolver(r *net.Resolver) {
+	s.mu.Lock()
+	s.r = r
+	s.mu.Unlock()
+}
+
+// Reports whether ip is in the set.  Must be called under RLock.
+func (s *IPSet) has(ip net.IP) bool {
+	for _, oldIP := range s.ips {
+		if oldIP.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Adds an IP to the set if it is not present.  Must be called under Lock.
+func (s *IPSet) add(ip net.IP) {
+	if !s.has(ip) {
+		s.ips = append(s.ips, ip)
+	}
+}
+
+// Add one or more IP addresses to the set.
+// The hostname can be a domain name or an IP address.
+func (s *IPSet) Add(hostname string) error {
+	// Don't hold the ipMap lock during blocking I/O.
+	resolved, err := s.r.LookupIPAddr(context.TODO(), hostname)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	for _, addr := range resolved {
+		s.add(addr.IP)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// Empty reports whether the set is empty.
+func (s *IPSet) Empty() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.ips) == 0
+}
+
+// GetAll returns a copy of the IP set as a slice in random order.
+// The slice is owned by the caller, but the elements are owned by the set.
+func (s *IPSet) GetAll() []net.IP {
+	s.mu.RLock()
+	c := append([]net.IP{}, s.ips...)
+	s.mu.RUnlock()
+	rand.Shuffle(len(c), func(i, j int) {
+		c[i], c[j] = c[j], c[i]
+	})
+	return c
+}
+
+// Confirmed returns the confirmed IP address, or nil if there is no such address.
+func (s *IPSet) Confirmed() net.IP {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.confirmed
+}
+
+// Confirm marks ip as the confirmed address.
+func (s *IPSet) Confirm(ip net.IP) {
+	// Optimization: Skip setting if it hasn't changed.
+	if ip.Equal(s.Confirmed()) {
+		// This is the common case.
+		return
+	}
+	s.mu.Lock()
+	// has() is O(N)
+	if s.has(ip) {
+		s.confirmed = ip
+	}
+	s.mu.Unlock()
+}
+
+func (s *IPSet) AddAndConfirm(ip net.IP) {
+	// Optimization: Skip setting if it hasn't changed.
+	if ip.Equal(s.Confirmed()) {
+		// This is the common case.
+		return
+	}
+	s.mu.Lock()
+	// Add is O(N)
+	s.add(ip)
+	s.confirmed = ip
+	s.mu.Unlock()
+}
+
+// Disconfirm sets the confirmed address to nil if the current confirmed address
+// is the provided ip.
+func (s *IPSet) Disconfirm(ip net.IP) {
+	s.mu.Lock()
+	if ip.Equal(s.confirmed) {
+		s.confirmed = nil
+	}
+	s.mu.Unlock()
+}

--- a/net/ipset/ipset_test.go
+++ b/net/ipset/ipset_test.go
@@ -1,0 +1,145 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipset
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+func TestInitEmpty(t *testing.T) {
+	s := IPSet{}
+	if !s.Empty() {
+		t.Error("Set should initially be empty")
+	}
+	if len(s.GetAll()) != 0 {
+		t.Error("Empty set should be empty")
+	}
+}
+
+func TestAddDomain(t *testing.T) {
+	s := IPSet{}
+	s.Add("www.google.com")
+	if s.Empty() {
+		t.Error("Google lookup failed")
+	}
+	ips := s.GetAll()
+	if len(ips) == 0 {
+		t.Fatal("IP set is empty")
+	}
+	if ips[0] == nil {
+		t.Error("nil IP in set")
+	}
+}
+func TestAddIP(t *testing.T) {
+	s := IPSet{}
+	s.Add("192.0.2.1")
+	ips := s.GetAll()
+	if len(ips) != 1 {
+		t.Errorf("Wrong IP set size %d", len(ips))
+	}
+	if ips[0].String() != "192.0.2.1" {
+		t.Error("Wrong IP")
+	}
+}
+
+func TestConfirmed(t *testing.T) {
+	s := IPSet{}
+	s.Add("www.google.com")
+	if s.Confirmed() != nil {
+		t.Error("Confirmed should start out nil")
+	}
+
+	ips := s.GetAll()
+	s.Confirm(ips[0])
+	if !ips[0].Equal(s.Confirmed()) {
+		t.Error("Confirmation failed")
+	}
+
+	s.Disconfirm(ips[0])
+	if s.Confirmed() != nil {
+		t.Error("Confirmed should now be nil")
+	}
+}
+
+func TestAddAndConfirm(t *testing.T) {
+	s := IPSet{}
+	s.Add("192.0.2.1")
+	// Add and confirm a new address.
+	s.AddAndConfirm(net.ParseIP("192.0.2.2"))
+	if s.Confirmed() == nil || s.Confirmed().String() != "192.0.2.2" {
+		t.Error("Confirmation failed")
+	}
+	ips := s.GetAll()
+	if len(ips) != 2 {
+		t.Error("New address not added to the set")
+	}
+}
+
+func TestConfirmMismatch(t *testing.T) {
+	s := IPSet{}
+	s.Add("192.0.2.1")
+	// Attempt to confirm an unknown address.
+	s.Confirm(net.ParseIP("192.0.2.2"))
+	if s.Confirmed() != nil {
+		t.Error("Confirmation should have failed")
+	}
+	ips := s.GetAll()
+	if len(ips) != 1 {
+		t.Error("New address should not have been added to the set")
+	}
+}
+
+func TestDisconfirmMismatch(t *testing.T) {
+	s := IPSet{}
+	s.Add("www.google.com")
+	ips := s.GetAll()
+	s.Confirm(ips[0])
+
+	// Make a copy
+	otherIP := net.ParseIP(ips[0].String())
+	// Alter it
+	otherIP[0]++
+	// Disconfirm.  This should have no effect because otherIP
+	// is not the confirmed IP.
+	s.Disconfirm(otherIP)
+
+	if !ips[0].Equal(s.Confirmed()) {
+		t.Error("Mismatched disconfirmation")
+	}
+}
+
+func TestResolver(t *testing.T) {
+	var dialCount int32
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(context context.Context, network, address string) (net.Conn, error) {
+			atomic.AddInt32(&dialCount, 1)
+			return nil, errors.New("Fake dialer")
+		},
+	}
+	s := IPSet{}
+	s.SetResolver(resolver)
+	s.Add("www.google.com")
+	if !s.Empty() {
+		t.Error("Google lookup should have failed due to fake dialer")
+	}
+	if atomic.LoadInt32(&dialCount) == 0 {
+		t.Error("Fake dialer didn't run")
+	}
+}


### PR DESCRIPTION
When using a proxy that is specified by hostname, this change causes the
client to try all IPs associated with that hostname until it finds one
that works.  (It will also prefer IPv6 addresses if they are present.)
If an IP stops working, the client will try the other ones, and repeat
the name resolution if necessary.

This change also copies IPSet from outline-go-tun2socks/doh/intra/ipmap
(with some additions) which will subsequently be removed there.

Related issues:
https://github.com/Jigsaw-Code/outline-client/issues/91
https://github.com/Jigsaw-Code/outline-client/issues/671
https://github.com/Jigsaw-Code/outline-server/issues/501