### PR TITLE
add rfc6598 reserved prefix

### DIFF
--- a/net/private_net.go
+++ b/net/private_net.go
@@ -29,6 +29,8 @@ func init() {
 		"192.168.0.0/16",
 		// RFC 4193: IPv6 ULAs
 		"fc00::/7",
+		// RFC 6598: reserved prefix for CGNAT
+		"100.64.0.0/10",
 	} {
 		_, subnet, _ := net.ParseCIDR(cidr)
 		privateNetworks = append(privateNetworks, subnet)


### PR DESCRIPTION
Just have been using Outline Shadowsocks Server for a great long while, and it worked pretty fine though,
utill few days ago an abuse alert Email from Hetnzer was received, warning that my server is "sending malicious UDP attack traffic".

![图片](https://user-images.githubusercontent.com/7822648/110572543-97fcc480-8194-11eb-9740-9da48716141d.png)

And here's their "evidence" -- UDP access log from their side:
![图片](https://user-images.githubusercontent.com/7822648/110572579-afd44880-8194-11eb-9114-f9c5ff61afeb.png)

To them it seemed that my server is constantly attacking that `100.64.blah.blah` address via UDP flooding.

A quick investigation revealed that this IP address is actually an IP address that is used and allocated by one of my users' ISP, and somehow the traffic is not correctly discarded. Looking at the code of Outline Shadowsocks Server, there is no `100.64.0.0/10` CGNAT prefix in private addresses.

So I've made this Pull Request. Hopefully this will prevent more users under CGNAT receiving some sorts of "Abuse Alert" from any VPS Providers.