### PR TITLE
🍁 UDP: Cache and reply from the same interface and IP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/shadowsocks/go-shadowsocks2 v0.1.4-0.20201002022019-75d43273f5a5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8 h1:AvbQYmiaaaza3cW3QXRyPo5kYgpFIzOAfeAAN7m3qQ4=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 h1:7ZDGnxgHAMw7thfC5bEos0RDAccZKxioiWBhfIe+tvw=
+golang.org/x/sys v0.0.0-20210915083310-ed5796bab164/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/net/net.go
+++ b/net/net.go
@@ -87,6 +87,12 @@ func Relay(leftConn, rightConn DuplexConn) (int64, int64, error) {
 	return n, rs.N, err
 }
 
+type UDPPacketConn interface {
+	net.PacketConn
+	ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error)
+	WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error)
+}
+
 type ConnectionError struct {
 	// TODO: create status enums and move to metrics.go
 	Status  string

--- a/server.go
+++ b/server.go
@@ -79,7 +79,7 @@ func (s *SSServer) startPort(portNum int) error {
 	if err != nil {
 		return fmt.Errorf("Failed to start TCP on port %v: %v", portNum, err)
 	}
-	packetConn, err := net.ListenUDP("udp", &net.UDPAddr{Port: portNum})
+	udpPacketConn, err := service.ListenUDP("udp", &net.UDPAddr{Port: portNum})
 	if err != nil {
 		return fmt.Errorf("Failed to start UDP on port %v: %v", portNum, err)
 	}
@@ -90,7 +90,7 @@ func (s *SSServer) startPort(portNum int) error {
 	port.udpService = service.NewUDPService(s.natTimeout, port.cipherList, s.m)
 	s.ports[portNum] = port
 	go port.tcpService.Serve(listener)
-	go port.udpService.Serve(packetConn)
+	go port.udpService.Serve(udpPacketConn)
 	return nil
 }
 

--- a/service/udp_default.go
+++ b/service/udp_default.go
@@ -1,0 +1,32 @@
+//go:build !linux
+// +build !linux
+
+// Copyright 2018 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"net"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+)
+
+func ListenUDP(network string, laddr *net.UDPAddr) (onet.UDPPacketConn, error) {
+	return net.ListenUDP(network, laddr)
+}
+
+func getOobForCache(clientOob []byte) []byte {
+	return nil
+}

--- a/service/udp_linux.go
+++ b/service/udp_linux.go
@@ -1,0 +1,122 @@
+// Copyright 2018 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"unsafe"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+	"golang.org/x/sys/unix"
+)
+
+func ListenUDP(network string, laddr *net.UDPAddr) (onet.UDPPacketConn, error) {
+	lc := &net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				// Always set IP_PKTINFO
+				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_PKTINFO, 1); err != nil {
+					logger.Errorf("failed to set socket option IP_PKTINFO: %v", err)
+					return
+				}
+				logger.Debugf("successfully set IP_PKTINFO on %s", network)
+
+				if network == "udp6" {
+					if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_RECVPKTINFO, 1); err != nil {
+						logger.Errorf("failed to set socket option IPV6_RECVPKTINFO: %v", err)
+						return
+					}
+					logger.Debugf("successfully set IPV6_RECVPKTINFO on %s", network)
+				}
+			})
+		},
+	}
+
+	conn, err := lc.ListenPacket(context.Background(), network, laddr.String())
+	if err != nil {
+		return nil, err
+	} else {
+		return conn.(onet.UDPPacketConn), err
+	}
+}
+
+func getOobForCache(clientOob []byte) []byte {
+	switch len(clientOob) {
+	case unix.SizeofCmsghdr + unix.SizeofInet4Pktinfo:
+		return getOobForCache4(clientOob)
+	case unix.SizeofCmsghdr + unix.SizeofInet6Pktinfo:
+		return getOobForCache6(clientOob)
+	case 0:
+		logger.Debug("getOobForCache processed empty oob")
+		return nil
+	default:
+		logger.Debugf("unknown oob length: %d", len(clientOob))
+		return nil
+	}
+}
+
+type oob4 struct {
+	cmsghdr unix.Cmsghdr
+	pktinfo unix.Inet4Pktinfo
+}
+
+func getOobForCache4(clientOob4 []byte) []byte {
+	cmsg := (*oob4)(unsafe.Pointer(&clientOob4))
+	if cmsg.cmsghdr.Level == unix.IPPROTO_IP && cmsg.cmsghdr.Type == unix.IP_PKTINFO {
+		logger.Debug("successfully cached oob type IP_PKTINFO")
+		return (*[unix.SizeofCmsghdr + unix.SizeofInet4Pktinfo]byte)(unsafe.Pointer(&oob4{
+			cmsghdr: unix.Cmsghdr{
+				Level: unix.IPPROTO_IP,
+				Type:  unix.IP_PKTINFO,
+				Len:   unix.SizeofCmsghdr + unix.SizeofInet4Pktinfo,
+			},
+			pktinfo: unix.Inet4Pktinfo{
+				Ifindex:  cmsg.pktinfo.Ifindex,
+				Spec_dst: cmsg.pktinfo.Spec_dst,
+			},
+		}))[:]
+	} else {
+		logger.Debugf("unknown client oob level %d type %d", cmsg.cmsghdr.Level, cmsg.cmsghdr.Type)
+		return nil
+	}
+}
+
+type oob6 struct {
+	cmsghdr unix.Cmsghdr
+	pktinfo unix.Inet6Pktinfo
+}
+
+func getOobForCache6(clientOob6 []byte) []byte {
+	cmsg := (*oob6)(unsafe.Pointer(&clientOob6))
+	if cmsg.cmsghdr.Level == unix.IPPROTO_IPV6 && cmsg.cmsghdr.Type == unix.IPV6_PKTINFO {
+		logger.Debug("successfully cached oob type IPV6_PKTINFO")
+		return (*[unix.SizeofCmsghdr + unix.SizeofInet6Pktinfo]byte)(unsafe.Pointer(&oob6{
+			cmsghdr: unix.Cmsghdr{
+				Level: unix.IPPROTO_IPV6,
+				Type:  unix.IPV6_PKTINFO,
+				Len:   unix.SizeofCmsghdr + unix.SizeofInet6Pktinfo,
+			},
+			pktinfo: unix.Inet6Pktinfo{
+				Addr:    cmsg.pktinfo.Addr,
+				Ifindex: cmsg.pktinfo.Ifindex,
+			},
+		}))[:]
+	} else {
+		logger.Debugf("unknown client oob level %d type %d", cmsg.cmsghdr.Level, cmsg.cmsghdr.Type)
+		return nil
+	}
+}

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -49,7 +49,7 @@ type packet struct {
 }
 
 type fakePacketConn struct {
-	net.PacketConn
+	onet.UDPPacketConn
 	send     chan packet
 	recv     chan packet
 	deadline time.Time
@@ -212,7 +212,7 @@ func setupNAT() (*fakePacketConn, *fakePacketConn, *natconn) {
 	nat := newNATmap(timeout, &natTestMetrics{}, &sync.WaitGroup{})
 	clientConn := makePacketConn()
 	targetConn := makePacketConn()
-	nat.Add(&clientAddr, clientConn, natCipher, targetConn, "ZZ", "key id")
+	nat.Add(&clientAddr, clientConn, nil, natCipher, targetConn, "ZZ", "key id")
 	entry := nat.Get(clientAddr.String())
 	return clientConn, targetConn, entry
 }


### PR DESCRIPTION
Previously, outline-ss-server simply writes the UDP response, which gets routed via the default gateway.

This behavior becomes a problem, when a server has multiple IP addresses of the same address family. Response UDP packets may get routed via a different interface or IP than the incoming packets. At the client's point of view, the outgoing UDP socket received packets from another IP. Most firewalls simply drop such packets.

This commit borrows the idea from https://github.com/WireGuard/wireguard-go/blob/master/conn/bind_linux.go, where IP_PKTINFO and IPV6_PKTINFO are used to determine the interface and IP where the incoming packets are from. Then we send the response using the information as socket out-of-band data to inform the kernel how to route the packets.

Currently it's only implemented for Linux. Implementing it for other platforms is simply not worth the effort, in my opinion.