### PR TITLE
Use the IP PacketConn to specify the local proxy IP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/shadowsocks/go-shadowsocks2 v0.1.4-0.20201002022019-75d43273f5a5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
+golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -121,7 +123,13 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8 h1:AvbQYmiaaaza3cW3QXRyPo5kYgpFIzOAfeAAN7m3qQ4=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -233,6 +233,7 @@ type udpRecord struct {
 type fakeUDPMetrics struct {
 	metrics.ShadowsocksMetrics
 	fakeLocation string
+	mu           sync.Mutex
 	up, down     []udpRecord
 	natAdded     int
 }
@@ -241,13 +242,19 @@ func (m *fakeUDPMetrics) GetLocation(addr net.Addr) (string, error) {
 	return m.fakeLocation, nil
 }
 func (m *fakeUDPMetrics) AddUDPPacketFromClient(clientLocation, accessKey, status string, clientProxyBytes, proxyTargetBytes int, timeToCipher time.Duration) {
+	m.mu.Lock()
 	m.up = append(m.up, udpRecord{clientLocation, accessKey, status, clientProxyBytes, proxyTargetBytes})
+	m.mu.Unlock()
 }
 func (m *fakeUDPMetrics) AddUDPPacketFromTarget(clientLocation, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
+	m.mu.Lock()
 	m.down = append(m.down, udpRecord{clientLocation, accessKey, status, targetProxyBytes, proxyClientBytes})
+	m.mu.Unlock()
 }
 func (m *fakeUDPMetrics) AddUDPNatEntry() {
+	m.mu.Lock()
 	m.natAdded++
+	m.mu.Unlock()
 }
 func (m *fakeUDPMetrics) RemoveUDPNatEntry() {
 	// Not tested because it requires waiting for a long timeout.

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -72,7 +72,7 @@ func startTCPEchoServer(t testing.TB) (*net.TCPListener, *sync.WaitGroup) {
 }
 
 func startUDPEchoServer(t testing.TB) (*net.UDPConn, *sync.WaitGroup) {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	if err != nil {
 		t.Fatalf("Proxy ListenUDP failed: %v", err)
 	}
@@ -256,7 +256,7 @@ func (m *fakeUDPMetrics) RemoveUDPNatEntry() {
 func TestUDPEcho(t *testing.T) {
 	echoConn, echoRunning := startUDPEchoServer(t)
 
-	proxyConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	proxyConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	if err != nil {
 		t.Fatalf("ListenTCP failed: %v", err)
 	}
@@ -496,7 +496,7 @@ func BenchmarkTCPMultiplexing(b *testing.B) {
 func BenchmarkUDPEcho(b *testing.B) {
 	echoConn, echoRunning := startUDPEchoServer(b)
 
-	proxyConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	proxyConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	if err != nil {
 		b.Fatalf("ListenTCP failed: %v", err)
 	}
@@ -544,7 +544,7 @@ func BenchmarkUDPEcho(b *testing.B) {
 func BenchmarkUDPManyKeys(b *testing.B) {
 	echoConn, echoRunning := startUDPEchoServer(b)
 
-	proxyConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	proxyConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
 	if err != nil {
 		b.Fatalf("ListenTCP failed: %v", err)
 	}

--- a/net/net.go
+++ b/net/net.go
@@ -1,14 +1,8 @@
 package net
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"net"
-	"runtime"
-
-	"golang.org/x/net/ipv4"
-	"golang.org/x/net/ipv6"
 )
 
 // DuplexConn is a net.Conn that allows for closing only the reader or writer end of
@@ -102,64 +96,4 @@ type ConnectionError struct {
 
 func NewConnectionError(status, message string, cause error) *ConnectionError {
 	return &ConnectionError{Status: status, Message: message, Cause: cause}
-}
-
-// ReadFromWithDst reads one packet from `conn` into `b` and returns the number
-// of bytes read, the source address, and the destination IP address.  It enables
-// recovery of the destination IP, which is otherwise lost for UDP connections
-// that are bound to `0.0.0.0` or `::`.
-func ReadFromWithDst(conn net.PacketConn, b []byte) (n int, src *net.UDPAddr, dst net.IP, err error) {
-	var tmpSrc net.Addr
-	if conn.LocalAddr().Network() == "udp4" {
-		ipv4Conn := ipv4.NewPacketConn(conn)
-		if err = ipv4Conn.SetControlMessage(ipv4.FlagDst, true); err != nil {
-			return
-		}
-		var cm *ipv4.ControlMessage
-		if n, cm, tmpSrc, err = ipv4Conn.ReadFrom(b); err != nil {
-			return
-		}
-		if cm != nil {
-			dst = cm.Dst
-		} else if runtime.GOOS != "windows" {
-			err = errors.New("control data is missing")
-			return
-		}
-	} else if conn.LocalAddr().Network() == "udp6" {
-		ipv6Conn := ipv6.NewPacketConn(conn)
-		if err = ipv6Conn.SetControlMessage(ipv6.FlagDst, true); err != nil {
-			return
-		}
-		var cm *ipv6.ControlMessage
-		if n, cm, tmpSrc, err = ipv6Conn.ReadFrom(b); err != nil {
-			return
-		}
-		if cm != nil {
-			dst = cm.Dst
-		} else if runtime.GOOS != "windows" {
-			err = errors.New("control data is missing")
-			return
-		}
-	} else {
-		err = fmt.Errorf("unsupported network: %s", conn.LocalAddr().Network())
-		return
-	}
-	src = tmpSrc.(*net.UDPAddr)
-	return
-}
-
-// WriteToWithSrc sends `b` to `dst` on `conn` from the specified source IP.
-// This can be useful when the system has multiple IP addresses of the same family.
-// Similar functionality can be achieved by binding a new UDP socket to a specific local address,
-// but that might run into problems if the port is already bound by an existing socket.
-func WriteToWithSrc(conn net.PacketConn, b []byte, src net.IP, dst *net.UDPAddr) (int, error) {
-	if conn.LocalAddr().Network() == "udp4" {
-		cm := &ipv4.ControlMessage{Src: src}
-		return ipv4.NewPacketConn(conn).WriteTo(b, cm, dst)
-	} else if conn.LocalAddr().Network() == "udp6" {
-		cm := &ipv6.ControlMessage{Src: src}
-		return ipv6.NewPacketConn(conn).WriteTo(b, cm, dst)
-	} else {
-		return 0, fmt.Errorf("unsupported network: %s", conn.LocalAddr().Network())
-	}
 }

--- a/net/net.go
+++ b/net/net.go
@@ -1,8 +1,14 @@
 package net
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"net"
+	"runtime"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 // DuplexConn is a net.Conn that allows for closing only the reader or writer end of
@@ -96,4 +102,64 @@ type ConnectionError struct {
 
 func NewConnectionError(status, message string, cause error) *ConnectionError {
 	return &ConnectionError{Status: status, Message: message, Cause: cause}
+}
+
+// ReadFromWithDst reads one packet from `conn` into `b` and returns the number
+// of bytes read, the source address, and the destination IP address.  It enables
+// recovery of the destination IP, which is otherwise lost for UDP connections
+// that are bound to `0.0.0.0` or `::`.
+func ReadFromWithDst(conn net.PacketConn, b []byte) (n int, src *net.UDPAddr, dst net.IP, err error) {
+	var tmpSrc net.Addr
+	if conn.LocalAddr().Network() == "udp4" {
+		ipv4Conn := ipv4.NewPacketConn(conn)
+		if err = ipv4Conn.SetControlMessage(ipv4.FlagDst, true); err != nil {
+			return
+		}
+		var cm *ipv4.ControlMessage
+		if n, cm, tmpSrc, err = ipv4Conn.ReadFrom(b); err != nil {
+			return
+		}
+		if cm != nil {
+			dst = cm.Dst
+		} else if runtime.GOOS != "windows" {
+			err = errors.New("control data is missing")
+			return
+		}
+	} else if conn.LocalAddr().Network() == "udp6" {
+		ipv6Conn := ipv6.NewPacketConn(conn)
+		if err = ipv6Conn.SetControlMessage(ipv6.FlagDst, true); err != nil {
+			return
+		}
+		var cm *ipv6.ControlMessage
+		if n, cm, tmpSrc, err = ipv6Conn.ReadFrom(b); err != nil {
+			return
+		}
+		if cm != nil {
+			dst = cm.Dst
+		} else if runtime.GOOS != "windows" {
+			err = errors.New("control data is missing")
+			return
+		}
+	} else {
+		err = fmt.Errorf("unsupported network: %s", conn.LocalAddr().Network())
+		return
+	}
+	src = tmpSrc.(*net.UDPAddr)
+	return
+}
+
+// WriteToWithSrc sends `b` to `dst` on `conn` from the specified source IP.
+// This can be useful when the system has multiple IP addresses of the same family.
+// Similar functionality can be achieved by binding a new UDP socket to a specific local address,
+// but that might run into problems if the port is already bound by an existing socket.
+func WriteToWithSrc(conn net.PacketConn, b []byte, src net.IP, dst *net.UDPAddr) (int, error) {
+	if conn.LocalAddr().Network() == "udp4" {
+		cm := &ipv4.ControlMessage{Src: src}
+		return ipv4.NewPacketConn(conn).WriteTo(b, cm, dst)
+	} else if conn.LocalAddr().Network() == "udp6" {
+		cm := &ipv6.ControlMessage{Src: src}
+		return ipv6.NewPacketConn(conn).WriteTo(b, cm, dst)
+	} else {
+		return 0, fmt.Errorf("unsupported network: %s", conn.LocalAddr().Network())
+	}
 }

--- a/net/udp_any.go
+++ b/net/udp_any.go
@@ -1,0 +1,115 @@
+// Copyright 2022 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"errors"
+	"net"
+	"runtime"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// UDPAnyConn extends net.PacketConn to allow reporting the destination IP
+// of incoming packets, and setting the source IP of outgoing packets.  This
+// is relevant for UDP connections that are bound to `0.0.0.0` or `::`.  In
+// these cases, net.PacketConn is not sufficient to enable sending a reply
+// from the expected source IP.
+type UDPAnyConn interface {
+	net.PacketConn
+	ReadToFrom(p []byte) (n int, src *net.UDPAddr, dst net.IP, err error)
+	WriteToFrom(p []byte, dst *net.UDPAddr, src net.IP) (int, error)
+}
+
+type udpAnyConnV4 struct {
+	net.PacketConn
+	v4 ipv4.PacketConn
+}
+
+// ListenAnyUDP4 returns a UDPAnyConn that is listening on all IPv4 addresses
+// at the specified port. If `port` is zero, the kernel will choose an open port.
+func ListenAnyUDP4(port int) (UDPAnyConn, error) {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+	if err != nil {
+		return nil, err
+	}
+	anyConn := &udpAnyConnV4{conn, *ipv4.NewPacketConn(conn)}
+	if err = anyConn.v4.SetControlMessage(ipv4.FlagDst, true); err != nil {
+		return nil, err
+	}
+	return anyConn, nil
+}
+
+func (c *udpAnyConnV4) ReadToFrom(p []byte) (n int, src *net.UDPAddr, dst net.IP, err error) {
+	var cm *ipv4.ControlMessage
+	var tmpSrc net.Addr
+	if n, cm, tmpSrc, err = c.v4.ReadFrom(p); err != nil {
+		return
+	}
+	if cm != nil {
+		dst = cm.Dst
+	} else if runtime.GOOS != "windows" {
+		err = errors.New("control data is missing")
+		return
+	}
+	src = tmpSrc.(*net.UDPAddr)
+	return
+}
+
+func (c *udpAnyConnV4) WriteToFrom(p []byte, dst *net.UDPAddr, src net.IP) (int, error) {
+	cm := &ipv4.ControlMessage{Src: src}
+	return c.v4.WriteTo(p, cm, dst)
+}
+
+type udpAnyConnV6 struct {
+	net.PacketConn
+	v6 ipv6.PacketConn
+}
+
+// ListenAnyUDP4 returns a UDPAnyConn that is listening on all IPv6 addresses
+// at the specified port. If `port` is zero, the kernel will choose an open port.
+func ListenAnyUDP6(port int) (UDPAnyConn, error) {
+	conn, err := net.ListenUDP("udp6", &net.UDPAddr{Port: port})
+	if err != nil {
+		return nil, err
+	}
+	anyConn := &udpAnyConnV6{conn, *ipv6.NewPacketConn(conn)}
+	if err = anyConn.v6.SetControlMessage(ipv6.FlagDst, true); err != nil {
+		return nil, err
+	}
+	return anyConn, nil
+}
+
+func (c *udpAnyConnV6) ReadToFrom(p []byte) (n int, src *net.UDPAddr, dst net.IP, err error) {
+	var cm *ipv6.ControlMessage
+	var tmpSrc net.Addr
+	if n, cm, tmpSrc, err = c.v6.ReadFrom(p); err != nil {
+		return
+	}
+	if cm != nil {
+		dst = cm.Dst
+	} else if runtime.GOOS != "windows" {
+		err = errors.New("control data is missing")
+		return
+	}
+	src = tmpSrc.(*net.UDPAddr)
+	return
+}
+
+func (c *udpAnyConnV6) WriteToFrom(p []byte, dst *net.UDPAddr, src net.IP) (int, error) {
+	cm := &ipv6.ControlMessage{Src: src}
+	return c.v6.WriteTo(p, cm, dst)
+}

--- a/net/udp_any_test.go
+++ b/net/udp_any_test.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"net"
+	"testing"
+)
+
+func TestListenAnyUDP4(t *testing.T) {
+	server, err := ListenAnyUDP4(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverPort := server.LocalAddr().(*net.UDPAddr).Port
+	serverAddr1 := &net.UDPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: serverPort,
+	}
+	client1, err := net.DialUDP("udp", nil, serverAddr1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverAddr2 := &net.UDPAddr{
+		IP:   net.ParseIP("127.0.0.2"),
+		Port: serverPort,
+	}
+	client2, err := net.DialUDP("udp", nil, serverAddr2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client1.Write([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2)
+	n, src, dst, err := server.ReadToFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("Unexpected length: %d", n)
+	}
+	if buf[0] != 1 {
+		t.Errorf("Unexpected contents: %v", buf[:n])
+	}
+	if src == nil {
+		t.Error("No source address")
+	}
+	if dst.String() != "127.0.0.1" {
+		t.Errorf("Unexpected destination: %v", dst)
+	}
+
+	if _, err := client2.Write([]byte{2}); err != nil {
+		t.Fatal(err)
+	}
+	n, src, dst, err = server.ReadToFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("Unexpected length: %d", n)
+	}
+	if buf[0] != 2 {
+		t.Errorf("Unexpected contents: %v", buf[:n])
+	}
+	if src == nil {
+		t.Error("No source address")
+	}
+	if dst.String() != "127.0.0.2" {
+		t.Errorf("Unexpected destination: %v", dst)
+	}
+}

--- a/net/udp_any_test.go
+++ b/net/udp_any_test.go
@@ -42,6 +42,7 @@ func TestListenAnyUDP4(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Receive a packet on 127.0.0.1
 	if _, err := client1.Write([]byte{1}); err != nil {
 		t.Fatal(err)
 	}
@@ -63,6 +64,7 @@ func TestListenAnyUDP4(t *testing.T) {
 		t.Errorf("Unexpected destination: %v", dst)
 	}
 
+	// Receive a packet on 127.0.0.2
 	if _, err := client2.Write([]byte{2}); err != nil {
 		t.Fatal(err)
 	}
@@ -81,5 +83,178 @@ func TestListenAnyUDP4(t *testing.T) {
 	}
 	if dst.String() != "127.0.0.2" {
 		t.Errorf("Unexpected destination: %v", dst)
+	}
+}
+
+func TestSendAnyUDP4(t *testing.T) {
+	server, err := ListenAnyUDP4(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverPort := server.LocalAddr().(*net.UDPAddr).Port
+	client, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientAddr := client.LocalAddr().(*net.UDPAddr)
+
+	serverIP1 := net.ParseIP("127.0.0.1")
+	serverIP2 := net.ParseIP("127.0.0.2")
+
+	// Send from 127.0.0.1
+	if _, err := server.WriteToFrom([]byte{1}, clientAddr, serverIP1); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2)
+	n, src, err := client.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("Unexpected length: %d", n)
+	}
+	if buf[0] != 1 {
+		t.Errorf("Unexpected contents: %v", buf[:n])
+	}
+	udpSrc := src.(*net.UDPAddr)
+	if !udpSrc.IP.Equal(serverIP1) {
+		t.Errorf("Wrong source IP: %v", src)
+	}
+	if udpSrc.Port != serverPort {
+		t.Errorf("Wrong source port: %v", src)
+	}
+
+	// Send from 127.0.0.2
+	if _, err := server.WriteToFrom([]byte{2}, clientAddr, serverIP2); err != nil {
+		t.Fatal(err)
+	}
+	n, src, err = client.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("Unexpected length: %d", n)
+	}
+	if buf[0] != 2 {
+		t.Errorf("Unexpected contents: %v", buf[:n])
+	}
+	udpSrc = src.(*net.UDPAddr)
+	if !udpSrc.IP.Equal(serverIP2) {
+		t.Errorf("Wrong source IP: %v", src)
+	}
+	if udpSrc.Port != serverPort {
+		t.Errorf("Wrong source port: %v", src)
+	}
+}
+
+func TestListenAnyUDP6(t *testing.T) {
+	server, err := ListenAnyUDP6(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverPort := server.LocalAddr().(*net.UDPAddr).Port
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ip.To4() != nil {
+				continue // Ignore IPv4
+			}
+
+			// Receive a packet on this IP address.
+			serverAddr := &net.UDPAddr{IP: ip, Port: serverPort, Zone: iface.Name}
+			client, err := net.DialUDP("udp6", nil, serverAddr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Write([]byte{1}); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]byte, 2)
+			n, src, dst, err := server.ReadToFrom(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != 1 {
+				t.Errorf("Unexpected length: %d", n)
+			}
+			if buf[0] != 1 {
+				t.Errorf("Unexpected contents: %v", buf[:n])
+			}
+			if src == nil {
+				t.Error("No source address")
+			}
+			if !ip.Equal(dst) {
+				t.Errorf("Unexpected destination: %v", dst)
+			}
+		}
+	}
+}
+
+func TestSendAnyUDP6(t *testing.T) {
+	server, err := ListenAnyUDP6(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverPort := server.LocalAddr().(*net.UDPAddr).Port
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ip.To4() != nil {
+				continue // Ignore IPv4
+			}
+
+			// Start a client listening on this IP.
+			clientInitAddr := &net.UDPAddr{IP: ip, Zone: iface.Name}
+			client, err := net.ListenUDP("udp6", clientInitAddr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			clientAddr := client.LocalAddr().(*net.UDPAddr)
+
+			// Send a packet to the client from the same IP.  This should
+			// avoid any issues with cross-interface routing rules.
+			if _, err := server.WriteToFrom([]byte{1}, clientAddr, ip); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]byte, 2)
+			n, src, err := client.ReadFromUDP(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != 1 {
+				t.Errorf("Unexpected length: %d", n)
+			}
+			if buf[0] != 1 {
+				t.Errorf("Unexpected contents: %v", buf[:n])
+			}
+			if !src.IP.Equal(ip) {
+				t.Errorf("Unexpected source IP (%v)", src.IP)
+			}
+			if src.Port != serverPort {
+				t.Errorf("Unexpected source port: %d", src.Port)
+			}
+		}
 	}
 }


### PR DESCRIPTION
This allows the proxy to determine the destination address of incoming
UDP packets and specify the source address of outgoing UDP packets.  It
requires duplicating the UDP service because it uses the x/net/ipv[4,6]
packages, which require us to know the address family of each incoming
packet before it is received.