### PR TITLE
Reduce metrics resources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
 * @Jigsaw-Code/outline-networking-owners
-
-*.md         @Jigsaw-Code/outline-strings-owners
-LICENSE      @Jigsaw-Code/outline-strings-owners

--- a/service/PROBES.md
+++ b/service/PROBES.md
@@ -29,7 +29,3 @@ This feature is on by default in Outline.  Admins who are using outline-ss-serve
 Shadowsocks uses the same Key Derivation Function for both upstream and downstream flows, so in principle an attacker could record data sent from the server to the client, and use it in a "reflected replay" attack as simulated client->server data.  The data would appear to be valid and authenticated to the server, but the connection would most likely fail when attempting to parse the destination address header, perhaps leading to a distinctive failure behavior.
 
 To avoid this class of attacks, outline-ss-server uses an [HMAC](https://en.wikipedia.org/wiki/HMAC) with a 32-bit tag to mark all server handshakes, and checks for the presence of this tag in all incoming handshakes.  If the tag is present, the connection is a reflected replay, with a false positive probability of 1 in 4 billion.
-
-## Metrics
-
-Outline provides server operators with metrics on a variety of aspects of server activity, including any detected attacks.  To observe attacks detected by your server, look at the `tcp_probes` histogram vector in Prometheus.  The `status` field will be `"ERR_CIPHER"` (indicating invalid probe data), `"ERR_REPLAY_CLIENT"`, or `"ERR_REPLAY_SERVER"`, depending on the kind of attack your server observed.  You can also see what country each probe appeared to originate from, and approximately how many bytes were sent before giving up.

--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -116,13 +116,13 @@ func newShadowsocksMetrics(ipCountryDB *geoip2.Reader) *shadowsocksMetrics {
 			prometheus.CounterOpts{
 				Namespace: "shadowsocks",
 				Name:      "data_bytes",
-				Help:      "Bytes transferred by the proxy",
+				Help:      "Bytes transferred by the proxy, per access key",
 			}, []string{"dir", "proto", "access_key"}),
 		dataBytesPerLocation: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: "shadowsocks",
 				Name:      "data_bytes_per_location",
-				Help:      "Bytes transferred by the proxy",
+				Help:      "Bytes transferred by the proxy, per location",
 			}, []string{"dir", "proto", "location"}),
 		timeToCipherMs: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -136,7 +136,7 @@ func newShadowsocksMetrics(ipCountryDB *geoip2.Reader) *shadowsocksMetrics {
 				Namespace: "shadowsocks",
 				Subsystem: "udp",
 				Name:      "packets_from_client_per_location",
-				Help:      "Packets received from the client",
+				Help:      "Packets received from the client, per location and status",
 			}, []string{"location", "status"}),
 		udpAddedNatEntries: prometheus.NewCounter(
 			prometheus.CounterOpts{

--- a/service/metrics/metrics_test.go
+++ b/service/metrics/metrics_test.go
@@ -20,7 +20,7 @@ func TestMethodsDontPanic(t *testing.T) {
 	ssMetrics.SetNumAccessKeys(20, 2)
 	ssMetrics.AddOpenTCPConnection("US")
 	ssMetrics.AddClosedTCPConnection("US", "1", "OK", proxyMetrics, 10*time.Millisecond, 100*time.Millisecond)
-	ssMetrics.AddTCPProbe("US", "ERR_CIPHER", "eof", 443, proxyMetrics)
+	ssMetrics.AddTCPProbe("ERR_CIPHER", "eof", 443, proxyMetrics)
 	ssMetrics.AddUDPPacketFromClient("US", "2", "OK", 10, 20, 10*time.Millisecond)
 	ssMetrics.AddUDPPacketFromTarget("US", "3", "OK", 10, 20)
 	ssMetrics.AddUDPNatEntry()
@@ -73,14 +73,13 @@ func BenchmarkCloseTCP(b *testing.B) {
 
 func BenchmarkProbe(b *testing.B) {
 	ssMetrics := NewPrometheusShadowsocksMetrics(nil, prometheus.NewRegistry())
-	clientLocation := "ZZ"
 	status := "ERR_REPLAY"
 	drainResult := "other"
 	port := 12345
 	data := ProxyMetrics{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ssMetrics.AddTCPProbe(clientLocation, status, drainResult, port, data)
+		ssMetrics.AddTCPProbe(status, drainResult, port, data)
 	}
 }
 

--- a/service/tcp.go
+++ b/service/tcp.go
@@ -321,7 +321,7 @@ func (s *tcpService) absorbProbe(listenerPort int, clientConn io.ReadCloser, cli
 	_, drainErr := io.Copy(ioutil.Discard, clientConn) // drain socket
 	drainResult := drainErrToString(drainErr)
 	logger.Debugf("Drain error: %v, drain result: %v", drainErr, drainResult)
-	s.m.AddTCPProbe(clientLocation, status, drainResult, listenerPort, *proxyMetrics)
+	s.m.AddTCPProbe(status, drainResult, listenerPort, *proxyMetrics)
 }
 
 func drainErrToString(drainErr error) string {

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -224,7 +224,7 @@ type probeTestMetrics struct {
 	closeStatus []string
 }
 
-func (m *probeTestMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data metrics.ProxyMetrics) {
+func (m *probeTestMetrics) AddTCPProbe(status, drainResult string, port int, data metrics.ProxyMetrics) {
 	m.mu.Lock()
 	m.probeData = append(m.probeData, data)
 	m.probeStatus = append(m.probeStatus, status)

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -102,7 +102,7 @@ type natTestMetrics struct {
 	upstreamPackets []udpReport
 }
 
-func (m *natTestMetrics) AddTCPProbe(clientLocation, status, drainResult string, port int, data metrics.ProxyMetrics) {
+func (m *natTestMetrics) AddTCPProbe(status, drainResult string, port int, data metrics.ProxyMetrics) {
 }
 func (m *natTestMetrics) AddClosedTCPConnection(clientLocation, accessKey, status string, data metrics.ProxyMetrics, timeToCipher, duration time.Duration) {
 }


### PR DESCRIPTION
This PR:
- Removes `location` from the `shadowsocks_tcp_probes` time series, which is the largest one.
- Removes 0s from `shadowsocks_data_bytes`.  We were creating 4 entries (each proxy leg) for every country that attempted to connect, even if they were unsuccessful connections. The metric was dominated by zeros.
- Reduces the cardinality of `shadowsocks_data_bytes` by removing the status and location. We don't need that for data limits. To enable country usage tracking, I introduce `shadowsocks_data_bytes_per_location`. To enable status tracking for UDP, I introduce `shadowsocks_udp_packets_from_client_per_location`. TCP already had `shadowsocks_connections_closed` for status tracking.