### PR TITLE
Clean up TCP serving

### DIFF
--- a/service/tcp.go
+++ b/service/tcp.go
@@ -17,6 +17,7 @@ package service
 import (
 	"bytes"
 	"container/list"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -109,13 +110,10 @@ func findEntry(firstBytes []byte, ciphers []*list.Element) (*CipherEntry, *list.
 	return nil, nil
 }
 
-type tcpService struct {
-	mu          sync.RWMutex // Protects .listeners and .stopped
-	listener    *net.TCPListener
-	stopped     bool
+type tcpHandler struct {
+	port        int
 	ciphers     CipherList
 	m           metrics.ShadowsocksMetrics
-	running     sync.WaitGroup
 	readTimeout time.Duration
 	// `replayCache` is a pointer to SSServer.replayCache, to share the cache among all ports.
 	replayCache       *ReplayCache
@@ -124,29 +122,25 @@ type tcpService struct {
 
 // NewTCPService creates a TCPService
 // `replayCache` is a pointer to SSServer.replayCache, to share the cache among all ports.
-func NewTCPService(ciphers CipherList, replayCache *ReplayCache, m metrics.ShadowsocksMetrics, timeout time.Duration) TCPService {
-	return &tcpService{
+func NewTCPHandler(port int, ciphers CipherList, replayCache *ReplayCache, m metrics.ShadowsocksMetrics, timeout time.Duration) TCPHandler {
+	return (&tcpHandler{
+		port:              port,
 		ciphers:           ciphers,
 		m:                 m,
 		readTimeout:       timeout,
 		replayCache:       replayCache,
 		targetIPValidator: onet.RequirePublicIP,
-	}
+	})
 }
 
 // TCPService is a Shadowsocks TCP service that can be started and stopped.
-type TCPService interface {
+type TCPHandler interface {
+	Handle(ctx context.Context, conn transport.StreamConn)
 	// SetTargetIPValidator sets the function to be used to validate the target IP addresses.
 	SetTargetIPValidator(targetIPValidator onet.TargetIPValidator)
-	// Serve adopts the listener, which will be closed before Serve returns.  Serve returns an error unless Stop() was called.
-	Serve(listener *net.TCPListener) error
-	// Stop closes the listener but does not interfere with existing connections.
-	Stop() error
-	// GracefulStop calls Stop(), and then blocks until all resources have been cleaned up.
-	GracefulStop() error
 }
 
-func (s *tcpService) SetTargetIPValidator(targetIPValidator onet.TargetIPValidator) {
+func (s *tcpHandler) SetTargetIPValidator(targetIPValidator onet.TargetIPValidator) {
 	s.targetIPValidator = targetIPValidator
 }
 
@@ -171,71 +165,73 @@ func dialTarget(tgtAddr socks.Addr, proxyMetrics *metrics.ProxyMetrics, targetIP
 	return metrics.MeasureConn(tgtTCPConn, &proxyMetrics.ProxyTarget, &proxyMetrics.TargetProxy), nil
 }
 
-func (s *tcpService) Serve(listener *net.TCPListener) error {
-	s.mu.Lock()
-	if s.listener != nil {
-		s.mu.Unlock()
-		listener.Close()
-		return errors.New("Serve called again. It must be called only once")
-	}
-	if s.stopped {
-		s.mu.Unlock()
-		return listener.Close()
-	}
-	s.listener = listener
-	s.running.Add(1)
-	s.mu.Unlock()
+type StreamListener func() (transport.StreamConn, error)
 
-	defer s.running.Done()
+func WrapStreamListener[T transport.StreamConn](f func() (T, error)) StreamListener {
+	return func() (transport.StreamConn, error) {
+		return f()
+	}
+}
+
+type StreamHandler func(ctx context.Context, conn transport.StreamConn)
+
+// StreamServe repeatedly calls `accept` to obtain connections and `handle` to handle them until
+// accept() returns [ErrClosed]. When that happens, all connection handlers will be notified
+// via their [context.Context]. StreamServe will return after all pending handlers return.
+func StreamServe(accept StreamListener, handle StreamHandler) {
+	var running sync.WaitGroup
+	defer running.Wait()
+	ctx, contextCancel := context.WithCancel(context.Background())
+	defer contextCancel()
 	for {
-		clientTCPConn, err := listener.AcceptTCP()
+		clientConn, err := accept()
 		if err != nil {
-			s.mu.RLock()
-			stopped := s.stopped
-			s.mu.RUnlock()
-			if stopped {
-				return nil
+			if errors.Is(err, net.ErrClosed) {
+				break
 			}
 			logger.Warningf("AcceptTCP failed: %v. Continuing to listen.", err)
 			continue
 		}
 
-		s.running.Add(1)
+		running.Add(1)
 		go func() {
-			defer s.running.Done()
+			defer running.Done()
+			defer clientConn.Close()
 			defer func() {
 				if r := recover(); r != nil {
 					logger.Warningf("Panic in TCP handler: %v. Continuing to listen.", r)
 				}
 			}()
-
-			clientTCPConn.SetKeepAlive(true)
-			clientLocation, err := s.m.GetLocation(clientTCPConn.RemoteAddr())
-			if err != nil {
-				logger.Warningf("Failed location lookup: %v", err)
-			}
-			logger.Debugf("Got location \"%v\" for IP %v", clientLocation, clientTCPConn.RemoteAddr().String())
-			s.m.AddOpenTCPConnection(clientLocation)
-			var proxyMetrics metrics.ProxyMetrics
-			clientConn := metrics.MeasureConn(clientTCPConn, &proxyMetrics.ProxyClient, &proxyMetrics.ClientProxy)
-			connStart := time.Now()
-
-			id, connError := s.handleConnection(listener.Addr().(*net.TCPAddr).Port, clientConn, &proxyMetrics)
-
-			connDuration := time.Now().Sub(connStart)
-			status := "OK"
-			if connError != nil {
-				status = connError.Status
-				logger.Debugf("TCP Error: %v: %v", connError.Message, connError.Cause)
-			}
-			s.m.AddClosedTCPConnection(clientLocation, id, status, proxyMetrics, connDuration)
-			clientConn.Close() // Closing after the metrics are added aids integration testing.
-			logger.Debugf("Done with status %v, duration %v", status, connDuration)
+			handle(ctx, clientConn)
 		}()
 	}
 }
 
-func (s *tcpService) handleConnection(listenerPort int, clientConn transport.StreamConn, proxyMetrics *metrics.ProxyMetrics) (string, *onet.ConnectionError) {
+func (s *tcpHandler) Handle(ctx context.Context, clientConn transport.StreamConn) {
+	clientLocation, err := s.m.GetLocation(clientConn.RemoteAddr())
+	if err != nil {
+		logger.Warningf("Failed location lookup: %v", err)
+	}
+	logger.Debugf("Got location \"%v\" for IP %v", clientLocation, clientConn.RemoteAddr().String())
+	s.m.AddOpenTCPConnection(clientLocation)
+	var proxyMetrics metrics.ProxyMetrics
+	measuredClientConn := metrics.MeasureConn(clientConn, &proxyMetrics.ProxyClient, &proxyMetrics.ClientProxy)
+	connStart := time.Now()
+
+	id, connError := s.handleConnection(s.port, measuredClientConn, &proxyMetrics)
+
+	connDuration := time.Now().Sub(connStart)
+	status := "OK"
+	if connError != nil {
+		status = connError.Status
+		logger.Debugf("TCP Error: %v: %v", connError.Message, connError.Cause)
+	}
+	s.m.AddClosedTCPConnection(clientLocation, id, status, proxyMetrics, connDuration)
+	measuredClientConn.Close() // Closing after the metrics are added aids integration testing.
+	logger.Debugf("Done with status %v, duration %v", status, connDuration)
+}
+
+func (s *tcpHandler) handleConnection(listenerPort int, clientConn transport.StreamConn, proxyMetrics *metrics.ProxyMetrics) (string, *onet.ConnectionError) {
 	// Set a deadline to receive the address to the target.
 	clientConn.SetReadDeadline(time.Now().Add(s.readTimeout))
 
@@ -321,7 +317,7 @@ func (s *tcpService) handleConnection(listenerPort int, clientConn transport.Str
 
 // Keep the connection open until we hit the authentication deadline to protect against probing attacks
 // `proxyMetrics` is a pointer because its value is being mutated by `clientConn`.
-func (s *tcpService) absorbProbe(listenerPort int, clientConn io.ReadCloser, status string, proxyMetrics *metrics.ProxyMetrics) {
+func (s *tcpHandler) absorbProbe(listenerPort int, clientConn io.ReadCloser, status string, proxyMetrics *metrics.ProxyMetrics) {
 	// This line updates proxyMetrics.ClientProxy before it's used in AddTCPProbe.
 	_, drainErr := io.Copy(ioutil.Discard, clientConn) // drain socket
 	drainResult := drainErrToString(drainErr)
@@ -339,20 +335,4 @@ func drainErrToString(drainErr error) string {
 	default:
 		return "other"
 	}
-}
-
-func (s *tcpService) Stop() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stopped = true
-	if s.listener == nil {
-		return nil
-	}
-	return s.listener.Close()
-}
-
-func (s *tcpService) GracefulStop() error {
-	err := s.Stop()
-	s.running.Wait()
-	return err
 }

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Jigsaw-Code/outline-internal-sdk/transport"
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	ss "github.com/Jigsaw-Code/outline-ss-server/shadowsocks"
@@ -126,10 +127,10 @@ func TestCompatibleCiphers(t *testing.T) {
 	}
 }
 
-// Fake DuplexConn
+// Fake StreamConn
 // 1-way pipe, representing the upstream flow as seen by the server.
 type conn struct {
-	onet.DuplexConn
+	transport.StreamConn
 	clientAddr net.Addr
 	reader     io.ReadCloser
 	writer     io.WriteCloser
@@ -286,8 +287,12 @@ func TestProbeRandom(t *testing.T) {
 	cipherList, err := MakeTestCiphers(ss.MakeTestSecrets(1))
 	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(cipherList, nil, testMetrics, 200*time.Millisecond)
-	go s.Serve(listener)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, nil, testMetrics, 200*time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	// 221 is the largest random probe reported by https://gfw.report/blog/gfw_shadowsocks/
 	buf := make([]byte, 221)
@@ -297,7 +302,8 @@ func TestProbeRandom(t *testing.T) {
 		err := probe(listener.Addr().(*net.TCPAddr), bytesToSend)
 		require.Nil(t, err, "Failed on byte %v: %v", numBytesToSend, err)
 	}
-	s.GracefulStop()
+	require.Nil(t, listener.Close())
+	<-done
 	require.Equal(t, len(buf), len(testMetrics.probeData))
 }
 
@@ -357,9 +363,13 @@ func TestProbeClientBytesBasicTruncated(t *testing.T) {
 	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(cipherList, nil, testMetrics, 200*time.Millisecond)
-	s.SetTargetIPValidator(allowAll)
-	go s.Serve(listener)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, nil, testMetrics, 200*time.Millisecond)
+	handler.SetTargetIPValidator(allowAll)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	discardListener, discardWait := startDiscardServer(t)
 	initialBytes := makeClientBytesBasic(t, cipher, discardListener.Addr().String())
@@ -369,7 +379,8 @@ func TestProbeClientBytesBasicTruncated(t *testing.T) {
 		err := probe(listener.Addr().(*net.TCPAddr), bytesToSend)
 		require.Nil(t, err, "Failed for %v bytes sent: %v", numBytesToSend, err)
 	}
-	s.GracefulStop()
+	listener.Close()
+	<-done
 	statusCount := testMetrics.countStatuses()
 	require.Equal(t, 50, statusCount["ERR_CIPHER"])
 	require.Equal(t, 7+16, statusCount["ERR_READ_ADDRESS"])
@@ -387,9 +398,13 @@ func TestProbeClientBytesBasicModified(t *testing.T) {
 	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(cipherList, nil, testMetrics, 200*time.Millisecond)
-	s.SetTargetIPValidator(allowAll)
-	go s.Serve(listener)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, nil, testMetrics, 200*time.Millisecond)
+	handler.SetTargetIPValidator(allowAll)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	discardListener, discardWait := startDiscardServer(t)
 	initialBytes := makeClientBytesBasic(t, cipher, discardListener.Addr().String())
@@ -402,7 +417,8 @@ func TestProbeClientBytesBasicModified(t *testing.T) {
 		require.Nil(t, err, "Failed modified byte %v: %v", byteToModify, err)
 	}
 
-	s.GracefulStop()
+	listener.Close()
+	<-done
 	statusCount := testMetrics.countStatuses()
 	require.Equal(t, 50, statusCount["ERR_CIPHER"])
 	require.Equal(t, 7+16, statusCount["ERR_READ_ADDRESS"])
@@ -418,9 +434,13 @@ func TestProbeClientBytesCoalescedModified(t *testing.T) {
 	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(cipherList, nil, testMetrics, 200*time.Millisecond)
-	s.SetTargetIPValidator(allowAll)
-	go s.Serve(listener)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, nil, testMetrics, 200*time.Millisecond)
+	handler.SetTargetIPValidator(allowAll)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	discardListener, discardWait := startDiscardServer(t)
 	initialBytes := makeClientBytesCoalesced(t, cipher, discardListener.Addr().String())
@@ -432,7 +452,8 @@ func TestProbeClientBytesCoalescedModified(t *testing.T) {
 		err := probe(listener.Addr().(*net.TCPAddr), bytesToSend)
 		require.Nil(t, err, "Failed modified byte %v: %v", byteToModify, err)
 	}
-	s.GracefulStop()
+	listener.Close()
+	<-done
 	statusCount := testMetrics.countStatuses()
 	require.Equal(t, 50, statusCount["ERR_CIPHER"])
 	require.Equal(t, len(initialBytes)-50, statusCount["ERR_READ_ADDRESS"]+statusCount["ERR_RELAY_CLIENT"])
@@ -456,8 +477,12 @@ func TestProbeServerBytesModified(t *testing.T) {
 	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(cipherList, nil, testMetrics, 200*time.Millisecond)
-	go s.Serve(listener)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, nil, testMetrics, 200*time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	initialBytes := makeServerBytes(t, cipher)
 	bytesToSend := make([]byte, len(initialBytes))
@@ -467,7 +492,8 @@ func TestProbeServerBytesModified(t *testing.T) {
 		err := probe(listener.Addr().(*net.TCPAddr), bytesToSend)
 		require.Nil(t, err, "Failed modified byte %v: %v", byteToModify, err)
 	}
-	s.GracefulStop()
+	listener.Close()
+	<-done
 	statusCount := testMetrics.countStatuses()
 	require.Equal(t, 50, statusCount["ERR_CIPHER"])
 	require.Equal(t, len(initialBytes)-50, statusCount["ERR_READ_ADDRESS"])
@@ -481,7 +507,7 @@ func TestReplayDefense(t *testing.T) {
 	replayCache := NewReplayCache(5)
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
-	s := NewTCPService(cipherList, &replayCache, testMetrics, testTimeout)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, &replayCache, testMetrics, testTimeout)
 	snapshot := cipherList.SnapshotForClientIP(nil)
 	cipherEntry := snapshot[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
@@ -504,7 +530,11 @@ func TestReplayDefense(t *testing.T) {
 		return conn
 	}
 
-	go s.Serve(listener)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	// First run.
 	conn1 := run()
@@ -523,7 +553,8 @@ func TestReplayDefense(t *testing.T) {
 	conn2.Read(make([]byte, 1))
 
 	conn1.Close()
-	s.GracefulStop()
+	listener.Close()
+	<-done
 
 	if len(testMetrics.probeData) == 1 {
 		clientProxyData := testMetrics.probeData[0]
@@ -554,7 +585,7 @@ func TestReverseReplayDefense(t *testing.T) {
 	replayCache := NewReplayCache(5)
 	testMetrics := &probeTestMetrics{}
 	const testTimeout = 200 * time.Millisecond
-	s := NewTCPService(cipherList, &replayCache, testMetrics, testTimeout)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, &replayCache, testMetrics, testTimeout)
 	snapshot := cipherList.SnapshotForClientIP(nil)
 	cipherEntry := snapshot[0].Value.(*CipherEntry)
 	cipher := cipherEntry.Cipher
@@ -568,7 +599,11 @@ func TestReverseReplayDefense(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go s.Serve(listener)
+	done := make(chan struct{})
+	go func() {
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
+	}()
 
 	conn, err := net.Dial(listener.Addr().Network(), listener.Addr().String())
 	if err != nil {
@@ -579,7 +614,8 @@ func TestReverseReplayDefense(t *testing.T) {
 		t.Error(err)
 	}
 	conn.Close()
-	s.GracefulStop()
+	listener.Close()
+	<-done
 
 	// The preamble should have been marked as a server replay.
 	if len(testMetrics.probeData) == 1 {
@@ -619,36 +655,37 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 	cipherList, err := MakeTestCiphers(ss.MakeTestSecrets(5))
 	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
 	testMetrics := &probeTestMetrics{}
-	s := NewTCPService(cipherList, nil, testMetrics, testTimeout)
+	handler := NewTCPHandler(listener.Addr().(*net.TCPAddr).Port, cipherList, nil, testMetrics, testTimeout)
 
-	testPayload := ss.MakeTestPayload(payloadSize)
-	done := make(chan bool)
+	done := make(chan struct{})
 	go func() {
-		defer func() { done <- true }()
-		timerStart := time.Now()
-		conn, err := net.Dial("tcp", listener.Addr().String())
-		if err != nil {
-			t.Fatalf("Failed to dial %v: %v", listener.Addr(), err)
-		}
-		conn.Write(testPayload)
-		buf := make([]byte, 1024)
-		bytesRead, err := conn.Read(buf) // will hang until connection is closed
-		elapsedTime := time.Since(timerStart)
-		switch {
-		case err != io.EOF:
-			t.Fatalf("Expected error EOF, got %v", err)
-		case bytesRead > 0:
-			t.Fatalf("Expected to read 0 bytes, got %v bytes", bytesRead)
-		case elapsedTime < testTimeout || elapsedTime > testTimeout+10*time.Millisecond:
-			t.Fatalf("Expected elapsed time close to %v, got %v", testTimeout, elapsedTime)
-		default:
-			// ok
-		}
+		StreamServe(WrapStreamListener(listener.AcceptTCP), handler.Handle)
+		done <- struct{}{}
 	}()
 
-	go s.Serve(listener)
+	testPayload := ss.MakeTestPayload(payloadSize)
+	timerStart := time.Now()
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to dial %v: %v", listener.Addr(), err)
+	}
+	conn.Write(testPayload)
+	buf := make([]byte, 1024)
+	bytesRead, err := conn.Read(buf) // will hang until connection is closed
+	elapsedTime := time.Since(timerStart)
+	switch {
+	case err != io.EOF:
+		t.Fatalf("Expected error EOF, got %v", err)
+	case bytesRead > 0:
+		t.Fatalf("Expected to read 0 bytes, got %v bytes", bytesRead)
+	case elapsedTime < testTimeout || elapsedTime > testTimeout+10*time.Millisecond:
+		t.Fatalf("Expected elapsed time close to %v, got %v", testTimeout, elapsedTime)
+	default:
+		// ok
+	}
+
+	listener.Close()
 	<-done
-	s.GracefulStop()
 
 	if len(testMetrics.probeData) == 1 {
 		clientProxyData := testMetrics.probeData[0]
@@ -676,49 +713,13 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 	}
 }
 
-func TestTCPDoubleServe(t *testing.T) {
-	cipherList, err := MakeTestCiphers(ss.MakeTestSecrets(1))
-	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
-	replayCache := NewReplayCache(5)
-	testMetrics := &probeTestMetrics{}
-	const testTimeout = 200 * time.Millisecond
-	s := NewTCPService(cipherList, &replayCache, testMetrics, testTimeout)
-
-	c := make(chan error)
-	for i := 0; i < 2; i++ {
-		listener := makeLocalhostListener(t)
-		go func() {
-			err := s.Serve(listener)
-			if err != nil {
-				c <- err
-				close(c)
-			}
-		}()
-	}
-
-	err = <-c
-	if err == nil {
-		t.Error("Expected an error from one of the two Serve calls")
-	}
-
-	if err := s.Stop(); err != nil {
-		t.Error(err)
-	}
-}
-
-func TestTCPEarlyStop(t *testing.T) {
-	cipherList, err := MakeTestCiphers(ss.MakeTestSecrets(1))
-	require.Nil(t, err, "MakeTestCiphers failed: %v", err)
-	replayCache := NewReplayCache(5)
-	testMetrics := &probeTestMetrics{}
-	const testTimeout = 200 * time.Millisecond
-	s := NewTCPService(cipherList, &replayCache, testMetrics, testTimeout)
-
-	if err := s.Stop(); err != nil {
-		t.Error(err)
-	}
-	listener := makeLocalhostListener(t)
-	if err := s.Serve(listener); err != nil {
-		t.Error(err)
-	}
+// Makes sure the TCP listener returns [io.ErrClosed] on Close().
+func TestClosedTCPListenerError(t *testing.T) {
+	tcpListener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	require.Nil(t, err)
+	accept := WrapStreamListener(tcpListener.AcceptTCP)
+	err = tcpListener.Close()
+	require.Nil(t, err)
+	_, err = accept()
+	require.ErrorIs(t, err, net.ErrClosed)
 }

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -528,3 +528,18 @@ func TestUDPEarlyStop(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// Makes sure the UDP listener returns [io.ErrClosed] on reads and writes after Close().
+func TestClosedUDPListenerError(t *testing.T) {
+	var packetConn net.PacketConn
+	packetConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	require.Nil(t, err)
+	err = packetConn.Close()
+	require.Nil(t, err)
+
+	_, _, err = packetConn.ReadFrom(nil)
+	require.ErrorIs(t, err, net.ErrClosed)
+
+	_, err = packetConn.WriteTo(nil, &net.UDPAddr{})
+	require.ErrorIs(t, err, net.ErrClosed)
+}


### PR DESCRIPTION
This PR makes the serving logic a lot simpler. Serve() was already tied to the listener lifetime, so now that's explicit, and closing the listener is the way to stop serving. We no longer need the complicated mutex logic.

This introduces a `StreamListener` concept that can return any type of StreamConn, allowing for listening on Unix sockets or introduce intermediate transports (e.g. Websockets). We no longer require TCP.

The handler will allow for easier replacement of the protocol in the future. That also makes it easier to test.