### PR TITLE
refactor: extract IP info package and add ASN support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/shadowsocks/go-shadowsocks2 v0.1.5
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/crypto v0.7.0
+	golang.org/x/term v0.6.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -160,7 +161,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.31.2/go.mod h1:qR6jVnZTKDCW3j+fC9mOEPHm++1nKDMkqbbkD6KNsfo=
-github.com/Jigsaw-Code/outline-internal-sdk v0.0.0-20230502182149-b8f111a1cdb2 h1:6i/9okipiPuLDEjvwWpCA/ZpoICJqUFBs1FVzJpfIVA=
-github.com/Jigsaw-Code/outline-internal-sdk v0.0.0-20230502182149-b8f111a1cdb2/go.mod h1:vxtE3esaFy5UG6TnipLyWx0esUQBy9LBXHLQx+SoER8=
 github.com/Jigsaw-Code/outline-internal-sdk v0.0.0-20230522235223-1b323ea1d667 h1:msZNpaFAjRTvVi5q2yW1PJ4MmU4/7anob2IZYtDZQJw=
 github.com/Jigsaw-Code/outline-internal-sdk v0.0.0-20230522235223-1b323ea1d667/go.mod h1:vxtE3esaFy5UG6TnipLyWx0esUQBy9LBXHLQx+SoER8=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/internal/integration_test/integration_test.go
+++ b/internal/integration_test/integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks"
+	"github.com/Jigsaw-Code/outline-ss-server/ipinfo"
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/Jigsaw-Code/outline-ss-server/service"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
@@ -166,7 +167,7 @@ type statusMetrics struct {
 	statuses []string
 }
 
-func (m *statusMetrics) AddClosedTCPConnection(clientInfo metrics.ClientInfo, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
+func (m *statusMetrics) AddClosedTCPConnection(clientInfo ipinfo.IPInfo, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
 	m.Lock()
 	m.statuses = append(m.statuses, status)
 	m.Unlock()
@@ -224,7 +225,7 @@ func TestRestrictedAddresses(t *testing.T) {
 
 // Metrics about one UDP packet.
 type udpRecord struct {
-	clientInfo        metrics.ClientInfo
+	clientInfo        ipinfo.IPInfo
 	accessKey, status string
 	in, out           int
 }
@@ -232,20 +233,20 @@ type udpRecord struct {
 // Fake metrics implementation for UDP
 type fakeUDPMetrics struct {
 	metrics.ShadowsocksMetrics
-	fakeInfo metrics.ClientInfo
+	fakeInfo ipinfo.IPInfo
 	up, down []udpRecord
 	natAdded int
 }
 
 var _ metrics.ShadowsocksMetrics = (*fakeUDPMetrics)(nil)
 
-func (m *fakeUDPMetrics) GetClientInfo(addr net.Addr) (metrics.ClientInfo, error) {
+func (m *fakeUDPMetrics) GetIPInfo(ip net.IP) (ipinfo.IPInfo, error) {
 	return m.fakeInfo, nil
 }
-func (m *fakeUDPMetrics) AddUDPPacketFromClient(clientInfo metrics.ClientInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
+func (m *fakeUDPMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
 	m.up = append(m.up, udpRecord{clientInfo, accessKey, status, clientProxyBytes, proxyTargetBytes})
 }
-func (m *fakeUDPMetrics) AddUDPPacketFromTarget(clientInfo metrics.ClientInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
+func (m *fakeUDPMetrics) AddUDPPacketFromTarget(clientInfo ipinfo.IPInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
 	m.down = append(m.down, udpRecord{clientInfo, accessKey, status, targetProxyBytes, proxyClientBytes})
 }
 func (m *fakeUDPMetrics) AddUDPNatEntry() {
@@ -268,7 +269,7 @@ func TestUDPEcho(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testMetrics := &fakeUDPMetrics{fakeInfo: metrics.ClientInfo{CountryCode: "QQ"}}
+	testMetrics := &fakeUDPMetrics{fakeInfo: ipinfo.IPInfo{CountryCode: "QQ"}}
 	proxy := service.NewPacketHandler(time.Hour, cipherList, testMetrics)
 	proxy.SetTargetIPValidator(allowAll)
 	done := make(chan struct{})
@@ -326,6 +327,7 @@ func TestUDPEcho(t *testing.T) {
 		t.Errorf("Wrong number of packets sent: %v", testMetrics.up)
 	} else {
 		record := testMetrics.up[0]
+		require.Equal(t, "QQ", record.clientInfo.CountryCode)
 		if record.clientInfo.CountryCode != "QQ" ||
 			record.accessKey != keyID ||
 			record.status != "OK" ||

--- a/internal/integration_test/integration_test.go
+++ b/internal/integration_test/integration_test.go
@@ -233,7 +233,6 @@ type udpRecord struct {
 // Fake metrics implementation for UDP
 type fakeUDPMetrics struct {
 	metrics.ShadowsocksMetrics
-	fakeInfo ipinfo.IPInfo
 	up, down []udpRecord
 	natAdded int
 }
@@ -241,7 +240,7 @@ type fakeUDPMetrics struct {
 var _ metrics.ShadowsocksMetrics = (*fakeUDPMetrics)(nil)
 
 func (m *fakeUDPMetrics) GetIPInfo(ip net.IP) (ipinfo.IPInfo, error) {
-	return m.fakeInfo, nil
+	return ipinfo.IPInfo{CountryCode: "QQ"}, nil
 }
 func (m *fakeUDPMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
 	m.up = append(m.up, udpRecord{clientInfo, accessKey, status, clientProxyBytes, proxyTargetBytes})
@@ -269,7 +268,7 @@ func TestUDPEcho(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testMetrics := &fakeUDPMetrics{fakeInfo: ipinfo.IPInfo{CountryCode: "QQ"}}
+	testMetrics := &fakeUDPMetrics{}
 	proxy := service.NewPacketHandler(time.Hour, cipherList, testMetrics)
 	proxy.SetTargetIPValidator(allowAll)
 	done := make(chan struct{})
@@ -327,8 +326,8 @@ func TestUDPEcho(t *testing.T) {
 		t.Errorf("Wrong number of packets sent: %v", testMetrics.up)
 	} else {
 		record := testMetrics.up[0]
-		require.Equal(t, "QQ", record.clientInfo.CountryCode)
-		if record.clientInfo.CountryCode != "QQ" ||
+		require.Equal(t, "XL", record.clientInfo.CountryCode.String())
+		if record.clientInfo.CountryCode != "XL" ||
 			record.accessKey != keyID ||
 			record.status != "OK" ||
 			record.in <= record.out ||
@@ -340,7 +339,7 @@ func TestUDPEcho(t *testing.T) {
 		t.Errorf("Wrong number of packets received: %v", testMetrics.down)
 	} else {
 		record := testMetrics.down[0]
-		if record.clientInfo.CountryCode != "QQ" ||
+		if record.clientInfo.CountryCode != "XL" ||
 			record.accessKey != keyID ||
 			record.status != "OK" ||
 			record.in != N ||

--- a/ipinfo/ipinfo.go
+++ b/ipinfo/ipinfo.go
@@ -45,10 +45,10 @@ const (
 // GetIPInfoFromAddr is a helper function to extract the IP address from the [net.Addr]
 // and call [IPInfoMap].GetIPInfo.
 // It uses special country codes to indicate errors:
-// - "XA": failed to extract the IP from the address
-// - "XL": IP is not global.
-// - "XD": error lookip up the country code
-// - "ZZ": lookup returned an empty country code.
+//   - "XA": failed to extract the IP from the address
+//   - "XL": IP is not global.
+//   - "XD": error lookip up the country code
+//   - "ZZ": lookup returned an empty country code.
 func GetIPInfoFromAddr(ip2info IPInfoMap, addr net.Addr) (IPInfo, error) {
 	var info IPInfo
 	if ip2info == nil {

--- a/ipinfo/ipinfo.go
+++ b/ipinfo/ipinfo.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipinfo
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+type IPInfoMap interface {
+	GetIPInfo(net.IP) (IPInfo, error)
+}
+
+type IPInfo struct {
+	CountryCode CountryCode
+	ASN         int
+}
+
+type CountryCode string
+
+func (cc CountryCode) String() string {
+	return string(cc)
+}
+
+const (
+	errParseAddr     CountryCode = "XA"
+	localLocation    CountryCode = "XL"
+	errDbLookupError CountryCode = "XD"
+	unknownLocation  CountryCode = "ZZ"
+)
+
+// GetIPInfoFromAddr is a helper function to extract the IP address from the [net.Addr]
+// and call [IPInfoMap].GetIPInfo.
+// It uses special country codes to indicate errors:
+// - "XA": failed to extract the IP from the address
+// - "XL": IP is not global.
+// - "XD": error lookip up the country code
+// - "ZZ": lookup returned an empty country code.
+func GetIPInfoFromAddr(ip2info IPInfoMap, addr net.Addr) (IPInfo, error) {
+	var info IPInfo
+	if ip2info == nil {
+		// Location is disabled. return empty info.
+		return info, nil
+	}
+
+	hostname, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		info.CountryCode = errParseAddr
+		return info, fmt.Errorf("failed to split hostname and port: %w", err)
+	}
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		info.CountryCode = errParseAddr
+		return info, errors.New("failed to parse address as IP")
+	}
+
+	if ip.IsLoopback() || ip.IsGlobalUnicast() {
+		info.CountryCode = localLocation
+		return info, nil
+	}
+	info, err = ip2info.GetIPInfo(ip)
+	if err != nil {
+		info.CountryCode = errDbLookupError
+	}
+	if info.CountryCode == "" {
+		info.CountryCode = unknownLocation
+	}
+	return info, err
+}

--- a/ipinfo/ipinfo_test.go
+++ b/ipinfo/ipinfo_test.go
@@ -1,0 +1,25 @@
+package ipinfo
+
+import (
+	"net"
+	"testing"
+)
+
+type noopMap struct{}
+
+func (*noopMap) GetIPInfo(ip net.IP) (IPInfo, error) {
+	return IPInfo{}, nil
+}
+
+func BenchmarkGetIPInfoFromAddr(b *testing.B) {
+	ip2info := &noopMap{}
+	testAddr := &net.TCPAddr{IP: net.ParseIP("217.65.48.1"), Port: 12345}
+
+	b.ResetTimer()
+	// Repeatedly check the country for the same address.  This is realistic, because
+	// servers call this method for each new connection, but typically many connections
+	// come from a single user in succession.
+	for i := 0; i < b.N; i++ {
+		GetIPInfoFromAddr(ip2info, testAddr)
+	}
+}

--- a/ipinfo/ipinfo_test.go
+++ b/ipinfo/ipinfo_test.go
@@ -1,14 +1,97 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package ipinfo
 
 import (
+	"errors"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type noopMap struct{}
 
 func (*noopMap) GetIPInfo(ip net.IP) (IPInfo, error) {
 	return IPInfo{}, nil
+}
+
+type badMap struct{}
+
+func (*badMap) GetIPInfo(ip net.IP) (IPInfo, error) {
+	return IPInfo{}, errors.New("bad map")
+}
+
+type badAddr struct {
+	address string
+}
+
+func (a *badAddr) String() string {
+	return a.address
+}
+
+func (a *badAddr) Network() string {
+	return "bad"
+}
+
+func TestGetIPInfoFromAddr(t *testing.T) {
+	var emptyInfo IPInfo
+	noInfoMap := &noopMap{}
+
+	// IP info disabled
+	info, err := GetIPInfoFromAddr(nil, nil)
+	require.Equal(t, emptyInfo, info)
+	require.NoError(t, err)
+
+	// Nil address
+	info, err = GetIPInfoFromAddr(noInfoMap, nil)
+	require.Error(t, err)
+	require.Equal(t, errParseAddr, info.CountryCode)
+
+	// Can't split host:port in address
+	info, err = GetIPInfoFromAddr(noInfoMap, &badAddr{"host-no-port"})
+	require.Error(t, err)
+	require.Equal(t, errParseAddr, info.CountryCode)
+
+	// Host is not an IP
+	info, err = GetIPInfoFromAddr(noInfoMap, &badAddr{"host-is-not-ip:port"})
+	require.Error(t, err)
+	require.Equal(t, errParseAddr, info.CountryCode)
+
+	// Localhost address
+	info, err = GetIPInfoFromAddr(noInfoMap, &badAddr{"127.0.0.1:port"})
+	require.NoError(t, err)
+	require.Equal(t, localLocation, info.CountryCode)
+
+	// Local network address
+	info, err = GetIPInfoFromAddr(noInfoMap, &badAddr{"10.0.0.1:port"})
+	require.NoError(t, err)
+	require.Equal(t, unknownLocation, info.CountryCode)
+
+	// No country found
+	info, err = GetIPInfoFromAddr(noInfoMap, &badAddr{"8.8.8.8:port"})
+	require.NoError(t, err)
+	require.Equal(t, unknownLocation, info.CountryCode)
+
+	// Failed DB lookup
+	info, err = GetIPInfoFromAddr(&badMap{}, &badAddr{"8.8.8.8:port"})
+	require.Error(t, err)
+	require.Equal(t, errDbLookupError, info.CountryCode)
+}
+
+func TestCountryCode(t *testing.T) {
+	require.Equal(t, "BR", CountryCode("BR").String())
 }
 
 func BenchmarkGetIPInfoFromAddr(b *testing.B) {

--- a/ipinfo/ipinfo_test.go
+++ b/ipinfo/ipinfo_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ipinfo
 
 import (

--- a/ipinfo/mmdb.go
+++ b/ipinfo/mmdb.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipinfo
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/oschwald/geoip2-golang"
+)
+
+// mmIPInfoMap is a [ipinfo.IPInfoMap] that uses [geoip2.Reader] to read MMDB files.
+type mmIPInfoMap struct {
+	countryDB *geoip2.Reader
+}
+
+// NewMMDBIPInfoMap creates a [ipinfo.IPInfoMap] that uses [geoip2.Reader] to lookup IP information from a MMDB.
+func NewMMDBIPInfoMap(countryDB *geoip2.Reader) IPInfoMap {
+	return &mmIPInfoMap{countryDB}
+}
+
+var _ IPInfoMap = (*mmIPInfoMap)(nil)
+
+func (ip2info *mmIPInfoMap) GetIPInfo(ip net.IP) (IPInfo, error) {
+	var info IPInfo
+	if ip2info == nil || ip2info.countryDB == nil {
+		// Location is disabled. return empty info.
+		return info, nil
+	}
+	record, err := ip2info.countryDB.Country(ip)
+	if err != nil {
+		info.CountryCode = errDbLookupError
+		return info, fmt.Errorf("IP lookup failed: %w", err)
+	}
+	if record != nil && record.Country.IsoCode != "" {
+		info.CountryCode = CountryCode(record.Country.IsoCode)
+	}
+	return info, nil
+}

--- a/ipinfo/mmdb.go
+++ b/ipinfo/mmdb.go
@@ -22,7 +22,7 @@ import (
 	"github.com/oschwald/geoip2-golang"
 )
 
-// MMDBIpInfoMap is a [ipinfo.IPInfoMap] that uses MMDB files to lookup IP information.
+// MMDBIpInfoMap is an [ipinfo.IPInfoMap] that uses MMDB files to lookup IP information.
 type MMDBIPInfoMap struct {
 	countryDB *geoip2.Reader
 	asnDB     *geoip2.Reader
@@ -30,7 +30,7 @@ type MMDBIPInfoMap struct {
 
 var _ IPInfoMap = (*MMDBIPInfoMap)(nil)
 
-// NewMMDBIPInfoMap creates a [ipinfo.IPInfoMap] that uses the MMDB at countryDBPath to lookup IP Country information
+// NewMMDBIPInfoMap creates an [ipinfo.IPInfoMap] that uses the MMDB at countryDBPath to lookup IP Country information
 // and the MMDB at asnDBPath to lookup IP ASN information. Either may be "", in which case you won't get the corresponding
 // information in the IPInfo.
 func NewMMDBIPInfoMap(countryDBPath string, asnDBPath string) (*MMDBIPInfoMap, error) {
@@ -68,7 +68,6 @@ func (ip2info *MMDBIPInfoMap) GetIPInfo(ip net.IP) (IPInfo, error) {
 		var record *geoip2.Country
 		record, countryErr = ip2info.countryDB.Country(ip)
 		if countryErr != nil {
-			info.CountryCode = errDbLookupError
 			countryErr = fmt.Errorf("country lookup failed: %w", countryErr)
 		} else if record != nil && record.Country.IsoCode != "" {
 			info.CountryCode = CountryCode(record.Country.IsoCode)
@@ -77,7 +76,9 @@ func (ip2info *MMDBIPInfoMap) GetIPInfo(ip net.IP) (IPInfo, error) {
 	if ip2info.asnDB != nil {
 		var record *geoip2.ASN
 		record, asnErr = ip2info.asnDB.ASN(ip)
-		if asnErr == nil && record != nil {
+		if asnErr != nil {
+			asnErr = fmt.Errorf("asn lookup failed: %w", asnErr)
+		} else if record != nil {
 			info.ASN = int(record.AutonomousSystemNumber)
 		}
 	}

--- a/ipinfo/mmdb_test.go
+++ b/ipinfo/mmdb_test.go
@@ -16,16 +16,47 @@ package ipinfo
 
 import (
 	"net"
+	"os"
 	"testing"
 
 	"github.com/oschwald/geoip2-golang"
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkNewMMDBIPInfoMap(b *testing.B) {
-	var ipCountryDB *geoip2.Reader
+func ensureTestData(tb testing.TB, dbPath string) {
+	_, err := os.Stat(dbPath)
+	if os.IsNotExist(err) {
+		tb.Skip("Test MMDB not found. Run git submodule update --init --depth=1")
+	}
+	require.NoError(tb, err)
+}
+
+func TestIPInfoMap(t *testing.T) {
 	// The test data is in a git submodule that must be initialized before running the test.
-	dbPath := "../third_party/maxmind/test-data/GeoIP2-Country-Test.mmdb"
+	dbPath := "../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb"
+	ensureTestData(t, dbPath)
+	ipCountryDB, err := geoip2.Open(dbPath)
+	require.NoError(t, err, "Could not open geoip database at %v: %v", dbPath, err)
+	defer ipCountryDB.Close()
+	ip2info := NewMMDBIPInfoMap(ipCountryDB)
+
+	info, err := ip2info.GetIPInfo(net.ParseIP("217.65.48.1"))
+	require.NoError(t, err)
+	require.Equal(t, IPInfo{CountryCode: "GI"}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("127.0.0.1"))
+	require.NoError(t, err)
+	require.Equal(t, IPInfo{CountryCode: ""}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("2001:250::"))
+	require.NoError(t, err)
+	require.Equal(t, IPInfo{CountryCode: "CN"}, info)
+}
+
+func BenchmarkNewMMDBIPInfoMap(b *testing.B) {
+	// The test data is in a git submodule that must be initialized before running the test.
+	dbPath := "../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb"
+	ensureTestData(b, dbPath)
 	ipCountryDB, err := geoip2.Open(dbPath)
 	require.NoError(b, err, "Could not open geoip database at %v: %v", dbPath, err)
 	defer ipCountryDB.Close()

--- a/ipinfo/mmdb_test.go
+++ b/ipinfo/mmdb_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipinfo
+
+import (
+	"net"
+	"testing"
+
+	"github.com/oschwald/geoip2-golang"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkNewMMDBIPInfoMap(b *testing.B) {
+	var ipCountryDB *geoip2.Reader
+	// The test data is in a git submodule that must be initialized before running the test.
+	dbPath := "../third_party/maxmind/test-data/GeoIP2-Country-Test.mmdb"
+	ipCountryDB, err := geoip2.Open(dbPath)
+	require.NoError(b, err, "Could not open geoip database at %v: %v", dbPath, err)
+	defer ipCountryDB.Close()
+	ip2info := NewMMDBIPInfoMap(ipCountryDB)
+
+	// testIP := net.ParseIP("127.0.0.1")
+	testIP := net.ParseIP("217.65.48.1")
+	b.ResetTimer()
+	// Repeatedly check the country for the same address.  This is realistic, because
+	// servers call this method for each new connection, but typically many connections
+	// come from a single user in succession.
+	for i := 0; i < b.N; i++ {
+		ip2info.GetIPInfo(testIP)
+	}
+}

--- a/ipinfo/mmdb_test.go
+++ b/ipinfo/mmdb_test.go
@@ -19,50 +19,103 @@ import (
 	"os"
 	"testing"
 
-	"github.com/oschwald/geoip2-golang"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func ensureTestData(tb testing.TB, dbPath string) {
-	_, err := os.Stat(dbPath)
+func ensureTestData(tb testing.TB) {
+	_, err := os.Stat("../third_party/maxmind/test-data/")
 	if os.IsNotExist(err) {
-		tb.Skip("Test MMDB not found. Run git submodule update --init --depth=1")
+		// The test data is in a git submodule that must be initialized before running the test.
+		tb.Skip("Test MMDB directory not found. Make sure you ran `git submodule update --init --depth=1`")
 	}
-	require.NoError(tb, err)
 }
 
-func TestIPInfoMap(t *testing.T) {
-	// The test data is in a git submodule that must be initialized before running the test.
-	dbPath := "../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb"
-	ensureTestData(t, dbPath)
-	ipCountryDB, err := geoip2.Open(dbPath)
-	require.NoError(t, err, "Could not open geoip database at %v: %v", dbPath, err)
-	defer ipCountryDB.Close()
-	ip2info := NewMMDBIPInfoMap(ipCountryDB)
-
-	info, err := ip2info.GetIPInfo(net.ParseIP("217.65.48.1"))
+func TestIPInfoMapCountryOnly(t *testing.T) {
+	ensureTestData(t)
+	ip2info, err := NewMMDBIPInfoMap("../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb", "")
 	require.NoError(t, err)
-	require.Equal(t, IPInfo{CountryCode: "GI"}, info)
+	defer ip2info.Close()
+
+	// For examples, see https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-Country-Test.json
+	info, err := ip2info.GetIPInfo(net.ParseIP("111.235.160.0"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{CountryCode: "CN"}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("2a02:d280::"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{CountryCode: "CZ"}, info)
 
 	info, err = ip2info.GetIPInfo(net.ParseIP("127.0.0.1"))
 	require.NoError(t, err)
-	require.Equal(t, IPInfo{CountryCode: ""}, info)
+	assert.Equal(t, IPInfo{}, info)
 
-	info, err = ip2info.GetIPInfo(net.ParseIP("2001:250::"))
+	info, err = ip2info.GetIPInfo(net.ParseIP("::1"))
 	require.NoError(t, err)
-	require.Equal(t, IPInfo{CountryCode: "CN"}, info)
+	assert.Equal(t, IPInfo{}, info)
+}
+
+func TestIPInfoMapASNOnly(t *testing.T) {
+	ensureTestData(t)
+	ip2info, err := NewMMDBIPInfoMap("", "../third_party/maxmind/test-data/GeoLite2-ASN-Test.mmdb")
+	require.NoError(t, err)
+	defer ip2info.Close()
+
+	// For examples, see https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-ASN-Test.json
+	info, err := ip2info.GetIPInfo(net.ParseIP("38.108.80.24"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{ASN: 174}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("2400::1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{ASN: 4766}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("10.0.0.1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("127.0.0.1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("::1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{}, info)
+}
+
+func TestIPInfoMap(t *testing.T) {
+	ensureTestData(t)
+	ip2info, err := NewMMDBIPInfoMap("../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb", "../third_party/maxmind/test-data/GeoLite2-ASN-Test.mmdb")
+	require.NoError(t, err)
+	defer ip2info.Close()
+
+	info, err := ip2info.GetIPInfo(net.ParseIP("67.43.156.0"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{CountryCode: "BT", ASN: 35908}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("2a02:d280::"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{CountryCode: "CZ"}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("2400::1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{ASN: 4766}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("10.0.0.1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{}, info)
+
+	info, err = ip2info.GetIPInfo(net.ParseIP("127.0.0.1"))
+	require.NoError(t, err)
+	assert.Equal(t, IPInfo{}, info)
 }
 
 func BenchmarkNewMMDBIPInfoMap(b *testing.B) {
-	// The test data is in a git submodule that must be initialized before running the test.
-	dbPath := "../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb"
-	ensureTestData(b, dbPath)
-	ipCountryDB, err := geoip2.Open(dbPath)
-	require.NoError(b, err, "Could not open geoip database at %v: %v", dbPath, err)
-	defer ipCountryDB.Close()
-	ip2info := NewMMDBIPInfoMap(ipCountryDB)
+	ensureTestData(b)
+	ip2info, err := NewMMDBIPInfoMap("../third_party/maxmind/test-data/GeoLite2-Country-Test.mmdb", "../third_party/maxmind/test-data/GeoLite2-ASN-Test.mmdb")
+	require.NoError(b, err)
+	defer ip2info.Close()
 
-	// testIP := net.ParseIP("127.0.0.1")
 	testIP := net.ParseIP("217.65.48.1")
 	b.ResetTimer()
 	// Repeatedly check the country for the same address.  This is realistic, because

--- a/service/tcp.go
+++ b/service/tcp.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks"
+	"github.com/Jigsaw-Code/outline-ss-server/ipinfo"
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	logging "github.com/op/go-logging"
@@ -202,7 +203,7 @@ func StreamServe(accept StreamListener, handle StreamHandler) {
 }
 
 func (h *tcpHandler) Handle(ctx context.Context, clientConn transport.StreamConn) {
-	clientInfo, err := h.m.GetClientInfo(clientConn.RemoteAddr())
+	clientInfo, err := ipinfo.GetIPInfoFromAddr(h.m, clientConn.RemoteAddr())
 	if err != nil {
 		logger.Warningf("Failed client info lookup: %v", err)
 	}

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport"
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks"
+	"github.com/Jigsaw-Code/outline-ss-server/ipinfo"
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	logging "github.com/op/go-logging"
@@ -224,22 +225,22 @@ type probeTestMetrics struct {
 
 var _ metrics.ShadowsocksMetrics = (*probeTestMetrics)(nil)
 
-func (m *probeTestMetrics) AddClosedTCPConnection(clientInfo metrics.ClientInfo, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
+func (m *probeTestMetrics) AddClosedTCPConnection(clientInfo ipinfo.IPInfo, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
 	m.mu.Lock()
 	m.closeStatus = append(m.closeStatus, status)
 	m.mu.Unlock()
 }
 
-func (m *probeTestMetrics) GetClientInfo(net.Addr) (metrics.ClientInfo, error) {
-	return metrics.ClientInfo{}, nil
+func (m *probeTestMetrics) GetIPInfo(net.IP) (ipinfo.IPInfo, error) {
+	return ipinfo.IPInfo{}, nil
 }
 func (m *probeTestMetrics) SetNumAccessKeys(numKeys int, numPorts int) {
 }
-func (m *probeTestMetrics) AddOpenTCPConnection(clientInfo metrics.ClientInfo) {
+func (m *probeTestMetrics) AddOpenTCPConnection(clientInfo ipinfo.IPInfo) {
 }
-func (m *probeTestMetrics) AddUDPPacketFromClient(clientInfo metrics.ClientInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
+func (m *probeTestMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
 }
-func (m *probeTestMetrics) AddUDPPacketFromTarget(clientInfo metrics.ClientInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
+func (m *probeTestMetrics) AddUDPPacketFromTarget(clientInfo ipinfo.IPInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
 }
 func (m *probeTestMetrics) AddUDPNatEntry()    {}
 func (m *probeTestMetrics) RemoveUDPNatEntry() {}

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-internal-sdk/transport/shadowsocks"
+	"github.com/Jigsaw-Code/outline-ss-server/ipinfo"
 	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	logging "github.com/op/go-logging"
@@ -92,7 +93,7 @@ func (conn *fakePacketConn) Close() error {
 }
 
 type udpReport struct {
-	clientInfo                         metrics.ClientInfo
+	clientInfo                         ipinfo.IPInfo
 	accessKey, status                  string
 	clientProxyBytes, proxyTargetBytes int
 }
@@ -106,19 +107,19 @@ type natTestMetrics struct {
 
 var _ metrics.ShadowsocksMetrics = (*natTestMetrics)(nil)
 
-func (m *natTestMetrics) AddClosedTCPConnection(clientInfo metrics.ClientInfo, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
+func (m *natTestMetrics) AddClosedTCPConnection(clientInfo ipinfo.IPInfo, accessKey, status string, data metrics.ProxyMetrics, duration time.Duration) {
 }
-func (m *natTestMetrics) GetClientInfo(net.Addr) (metrics.ClientInfo, error) {
-	return metrics.ClientInfo{}, nil
+func (m *natTestMetrics) GetIPInfo(net.IP) (ipinfo.IPInfo, error) {
+	return ipinfo.IPInfo{}, nil
 }
 func (m *natTestMetrics) SetNumAccessKeys(numKeys int, numPorts int) {
 }
-func (m *natTestMetrics) AddOpenTCPConnection(clientInfo metrics.ClientInfo) {
+func (m *natTestMetrics) AddOpenTCPConnection(clientInfo ipinfo.IPInfo) {
 }
-func (m *natTestMetrics) AddUDPPacketFromClient(clientInfo metrics.ClientInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
+func (m *natTestMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
 	m.upstreamPackets = append(m.upstreamPackets, udpReport{clientInfo, accessKey, status, clientProxyBytes, proxyTargetBytes})
 }
-func (m *natTestMetrics) AddUDPPacketFromTarget(clientInfo metrics.ClientInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
+func (m *natTestMetrics) AddUDPPacketFromTarget(clientInfo ipinfo.IPInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
 }
 func (m *natTestMetrics) AddUDPNatEntry() {
 	m.natEntriesAdded++
@@ -223,7 +224,7 @@ func setupNAT() (*fakePacketConn, *fakePacketConn, *natconn) {
 	nat := newNATmap(timeout, &natTestMetrics{}, &sync.WaitGroup{})
 	clientConn := makePacketConn()
 	targetConn := makePacketConn()
-	nat.Add(&clientAddr, clientConn, natCryptoKey, targetConn, metrics.ClientInfo{CountryCode: "ZZ"}, "key id")
+	nat.Add(&clientAddr, clientConn, natCryptoKey, targetConn, ipinfo.IPInfo{CountryCode: "ZZ"}, "key id")
 	entry := nat.Get(clientAddr.String())
 	return clientConn, targetConn, entry
 }


### PR DESCRIPTION
Move all the IP information to its own package and disentangle the IP->country logic from the helper around it to parse the IP and add extra codes. This makes it a lot easier to provide IPinfoMaps.

It also adds support for ASN lookups to the IPInfoMap.

Followup to [153](https://github.com/Jigsaw-Code/outline-ss-server/pull/153)
