### PR TITLE
refactor: remove explicit enabling of keepalive for tcp

### DIFF
--- a/cmd/outline-ss-server/main.go
+++ b/cmd/outline-ss-server/main.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
 	"github.com/Jigsaw-Code/outline-ss-server/ipinfo"
 	"github.com/Jigsaw-Code/outline-ss-server/service"
@@ -91,10 +90,7 @@ func (s *SSServer) startPort(portNum int) error {
 	tcpHandler := service.NewTCPHandler(portNum, authFunc, s.m, tcpReadTimeout)
 	packetHandler := service.NewPacketHandler(s.natTimeout, port.cipherList, s.m)
 	s.ports[portNum] = port
-	accept := func() (transport.StreamConn, error) {
-		return listener.AcceptTCP()
-	}
-	go service.StreamServe(accept, tcpHandler.Handle)
+	go service.StreamServe(service.WrapStreamListener(listener.AcceptTCP), tcpHandler.Handle)
 	go packetHandler.Handle(port.packetConn)
 	return nil
 }

--- a/cmd/outline-ss-server/main.go
+++ b/cmd/outline-ss-server/main.go
@@ -92,11 +92,7 @@ func (s *SSServer) startPort(portNum int) error {
 	packetHandler := service.NewPacketHandler(s.natTimeout, port.cipherList, s.m)
 	s.ports[portNum] = port
 	accept := func() (transport.StreamConn, error) {
-		conn, err := listener.AcceptTCP()
-		if err == nil {
-			conn.SetKeepAlive(true)
-		}
-		return conn, err
+		return listener.AcceptTCP()
 	}
 	go service.StreamServe(accept, tcpHandler.Handle)
 	go packetHandler.Handle(port.packetConn)


### PR DESCRIPTION
TCP keepalives have been enabled by default since Go 1.13, see [107196: net: enable TCP keepalives by default](https://go-review.git.corp.google.com/c/go/+/107196).