### PR TITLE
refactor: modularize UDP connection handling

### DIFF
--- a/cmd/outline-ss-server/metrics.go
+++ b/cmd/outline-ss-server/metrics.go
@@ -324,12 +324,12 @@ func (m *outlineMetrics) AddClosedTCPConnection(clientInfo ipinfo.IPInfo, client
 	}
 }
 
-func (m *outlineMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
+func (m *outlineMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, data metrics.ProxyMetrics) {
 	m.udpPacketsFromClientPerLocation.WithLabelValues(clientInfo.CountryCode.String(), asnLabel(clientInfo.ASN), status).Inc()
-	addIfNonZero(int64(clientProxyBytes), m.dataBytes, "c>p", "udp", accessKey)
-	addIfNonZero(int64(clientProxyBytes), m.dataBytesPerLocation, "c>p", "udp", clientInfo.CountryCode.String(), asnLabel(clientInfo.ASN))
-	addIfNonZero(int64(proxyTargetBytes), m.dataBytes, "p>t", "udp", accessKey)
-	addIfNonZero(int64(proxyTargetBytes), m.dataBytesPerLocation, "p>t", "udp", clientInfo.CountryCode.String(), asnLabel(clientInfo.ASN))
+	addIfNonZero(data.ClientProxy, m.dataBytes, "c>p", "udp", accessKey)
+	addIfNonZero(data.ClientProxy, m.dataBytesPerLocation, "c>p", "udp", clientInfo.CountryCode.String(), asnLabel(clientInfo.ASN))
+	addIfNonZero(data.ProxyTarget, m.dataBytes, "p>t", "udp", accessKey)
+	addIfNonZero(data.ProxyTarget, m.dataBytesPerLocation, "p>t", "udp", clientInfo.CountryCode.String(), asnLabel(clientInfo.ASN))
 }
 
 func (m *outlineMetrics) AddUDPPacketFromTarget(clientInfo ipinfo.IPInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {

--- a/internal/integration_test/integration_test.go
+++ b/internal/integration_test/integration_test.go
@@ -262,8 +262,8 @@ var _ service.UDPMetrics = (*fakeUDPMetrics)(nil)
 func (m *fakeUDPMetrics) GetIPInfo(ip net.IP) (ipinfo.IPInfo, error) {
 	return ipinfo.IPInfo{CountryCode: "QQ"}, nil
 }
-func (m *fakeUDPMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, clientProxyBytes, proxyTargetBytes int) {
-	m.up = append(m.up, udpRecord{clientInfo, accessKey, status, clientProxyBytes, proxyTargetBytes})
+func (m *fakeUDPMetrics) AddUDPPacketFromClient(clientInfo ipinfo.IPInfo, accessKey, status string, data metrics.ProxyMetrics) {
+	m.up = append(m.up, udpRecord{clientInfo, accessKey, status, int(data.ClientProxy), int(data.ProxyTarget)})
 }
 func (m *fakeUDPMetrics) AddUDPPacketFromTarget(clientInfo ipinfo.IPInfo, accessKey, status string, targetProxyBytes, proxyClientBytes int) {
 	m.down = append(m.down, udpRecord{clientInfo, accessKey, status, targetProxyBytes, proxyClientBytes})

--- a/service/udp.go
+++ b/service/udp.go
@@ -316,7 +316,7 @@ func (m *natmap) Get(key string) *natconn {
 	return m.keyConn[key]
 }
 
-func (m *natmap) set(clientAddr net.Addr, pc net.PacketConn, clientInfo ipinfo.IPInfo) *natconn {
+func (m *natmap) set(key string, pc net.PacketConn, clientInfo ipinfo.IPInfo) *natconn {
 	entry := &natconn{
 		PacketConn:     pc,
 		clientInfo:     clientInfo,
@@ -326,7 +326,7 @@ func (m *natmap) set(clientAddr net.Addr, pc net.PacketConn, clientInfo ipinfo.I
 	m.Lock()
 	defer m.Unlock()
 
-	m.keyConn[clientAddr.String()] = entry
+	m.keyConn[key] = entry
 	return entry
 }
 
@@ -343,7 +343,7 @@ func (m *natmap) del(key string) net.PacketConn {
 }
 
 func (m *natmap) Add(clientAddr net.Addr, clientConn net.PacketConn, cryptoKey *shadowsocks.EncryptionKey, targetConn net.PacketConn, clientInfo ipinfo.IPInfo, keyID string) *natconn {
-	entry := m.set(clientAddr, targetConn, clientInfo)
+	entry := m.set(clientAddr.String(), targetConn, clientInfo)
 
 	m.metrics.AddUDPNatEntry(clientAddr, keyID)
 	m.running.Add(1)

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -469,7 +469,7 @@ func BenchmarkUDPUnpackRepeat(b *testing.B) {
 		cipherNumber := n % numCiphers
 		ip := ips[cipherNumber]
 		packet := packets[cipherNumber]
-		_, _, _, err := findAccessKeyUDP(ip, testBuf, packet, cipherList)
+		_, _, err := findAccessKeyUDP(ip, testBuf, packet, cipherList)
 		if err != nil {
 			b.Error(err)
 		}
@@ -498,7 +498,7 @@ func BenchmarkUDPUnpackSharedKey(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		ip := ips[n%numIPs]
-		_, _, _, err := findAccessKeyUDP(ip, testBuf, packet, cipherList)
+		_, _, err := findAccessKeyUDP(ip, testBuf, packet, cipherList)
 		if err != nil {
 			b.Error(err)
 		}


### PR DESCRIPTION
Split the packet handler's `Handle()` method into 3 distinct parts for authentication, proxy request extraction, and proxy handling. This is similar to what was done with the TCP handler in #173.

There's more refactoring that can be done in future PRs, but this should make it easier to follow what's happening.