### PR TITLE
ci: run CI job daily so we catch issues with runner changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: "0 13 * * *"  # Run daily at 1PM UTC.
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read


### PR DESCRIPTION
Added these daily runs to `outline-apps` and `outline-server` already. It will help us discover issues in our workflows at HEAD due to things like runner changes sooner.