### PR TITLE
refactor: 

### DIFF
--- a/cmd/outline-ss-server/main.go
+++ b/cmd/outline-ss-server/main.go
@@ -63,7 +63,7 @@ type ssPort struct {
 
 type SSServer struct {
 	natTimeout  time.Duration
-	m           *outlineMetrics
+	m           *outlineMetricsCollector
 	replayCache service.ReplayCache
 	ports       map[int]*ssPort
 }
@@ -168,7 +168,7 @@ func (s *SSServer) Stop() error {
 }
 
 // RunSSServer starts a shadowsocks server running, and returns the server or an error.
-func RunSSServer(filename string, natTimeout time.Duration, sm *outlineMetrics, replayHistory int) (*SSServer, error) {
+func RunSSServer(filename string, natTimeout time.Duration, sm *outlineMetricsCollector, replayHistory int) (*SSServer, error) {
 	server := &SSServer{
 		natTimeout:  natTimeout,
 		m:           sm,

--- a/cmd/outline-ss-server/main.go
+++ b/cmd/outline-ss-server/main.go
@@ -273,9 +273,11 @@ func main() {
 	}
 	defer ip2info.Close()
 
-	m := newPrometheusOutlineMetrics(ip2info, prometheus.DefaultRegisterer)
-	m.SetBuildInfo(version)
-	_, err = RunSSServer(flags.ConfigFile, flags.natTimeout, m, flags.replayHistory)
+	metrics := newPrometheusOutlineMetrics(ip2info)
+	r := prometheus.WrapRegistererWithPrefix("shadowsocks_", prometheus.DefaultRegisterer)
+	r.MustRegister(metrics)
+	metrics.SetBuildInfo(version)
+	_, err = RunSSServer(flags.ConfigFile, flags.natTimeout, metrics, flags.replayHistory)
 	if err != nil {
 		slog.Error("Server failed to start. Aborting.", "err", err)
 	}

--- a/cmd/outline-ss-server/metrics.go
+++ b/cmd/outline-ss-server/metrics.go
@@ -291,8 +291,8 @@ type outlineMetricsCollector struct {
 }
 
 var _ prometheus.Collector = (*outlineMetricsCollector)(nil)
-var _ service.TCPMetricsCollector = (*outlineMetricsCollector)(nil)
-var _ service.UDPMetricsCollector = (*outlineMetricsCollector)(nil)
+var _ service.TCPMetrics = (*outlineMetricsCollector)(nil)
+var _ service.UDPMetrics = (*outlineMetricsCollector)(nil)
 
 // newPrometheusOutlineMetrics constructs a Prometheus metrics collector that uses
 // `ip2info` to convert IP addresses to countries. `ip2info` may be nil.

--- a/cmd/outline-ss-server/metrics_test.go
+++ b/cmd/outline-ss-server/metrics_test.go
@@ -87,14 +87,14 @@ func TestTunnelTimePerKey(t *testing.T) {
 	setNow(time.Date(2010, 1, 2, 3, 4, 20, .0, time.Local))
 
 	expected := strings.NewReader(`
-	# HELP shadowsocks_tunnel_time_seconds Tunnel time, per access key.
-	# TYPE shadowsocks_tunnel_time_seconds counter
-	shadowsocks_tunnel_time_seconds{access_key="key-1"} 15
+	# HELP tunnel_time_seconds Tunnel time, per access key.
+	# TYPE tunnel_time_seconds counter
+	tunnel_time_seconds{access_key="key-1"} 15
 `)
 	err := promtest.GatherAndCompare(
 		reg,
 		expected,
-		"shadowsocks_tunnel_time_seconds",
+		"tunnel_time_seconds",
 	)
 	require.NoError(t, err, "unexpected metric value found")
 }
@@ -108,14 +108,14 @@ func TestTunnelTimePerLocation(t *testing.T) {
 	setNow(time.Date(2010, 1, 2, 3, 4, 10, .0, time.Local))
 
 	expected := strings.NewReader(`
-	# HELP shadowsocks_tunnel_time_seconds_per_location Tunnel time, per location.
-	# TYPE shadowsocks_tunnel_time_seconds_per_location counter
-	shadowsocks_tunnel_time_seconds_per_location{asn="",location="XL"} 5
+	# HELP tunnel_time_seconds_per_location Tunnel time, per location.
+	# TYPE tunnel_time_seconds_per_location counter
+	tunnel_time_seconds_per_location{asn="",location="XL"} 5
 `)
 	err := promtest.GatherAndCompare(
 		reg,
 		expected,
-		"shadowsocks_tunnel_time_seconds_per_location",
+		"tunnel_time_seconds_per_location",
 	)
 	require.NoError(t, err, "unexpected metric value found")
 }
@@ -129,7 +129,7 @@ func TestTunnelTimePerKeyDoesNotPanicOnUnknownClosedConnection(t *testing.T) {
 	err := promtest.GatherAndCompare(
 		reg,
 		strings.NewReader(""),
-		"shadowsocks_tunnel_time_seconds",
+		"tunnel_time_seconds",
 	)
 	require.NoError(t, err, "unexpectedly found metric value")
 }

--- a/service/tcp.go
+++ b/service/tcp.go
@@ -35,8 +35,8 @@ import (
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 )
 
-// TCPMetricsCollector is used to report metrics on TCP connections.
-type TCPMetricsCollector interface {
+// TCPMetrics is used to report metrics on TCP connections.
+type TCPMetrics interface {
 	AddOpenTCPConnection(clientAddr net.Addr)
 	AddAuthenticatedTCPConnection(clientAddr net.Addr, accessKey string)
 	AddClosedTCPConnection(clientAddr net.Addr, accessKey string, status string, data metrics.ProxyMetrics, duration time.Duration)
@@ -160,14 +160,14 @@ func NewShadowsocksStreamAuthenticator(ciphers CipherList, replayCache *ReplayCa
 
 type tcpHandler struct {
 	listenerId   string
-	m            TCPMetricsCollector
+	m            TCPMetrics
 	readTimeout  time.Duration
 	authenticate StreamAuthenticateFunc
 	dialer       transport.StreamDialer
 }
 
 // NewTCPService creates a TCPService
-func NewTCPHandler(authenticate StreamAuthenticateFunc, m TCPMetricsCollector, timeout time.Duration) TCPHandler {
+func NewTCPHandler(authenticate StreamAuthenticateFunc, m TCPMetrics, timeout time.Duration) TCPHandler {
 	return &tcpHandler{
 		m:            m,
 		readTimeout:  timeout,
@@ -381,18 +381,18 @@ func drainErrToString(drainErr error) string {
 	}
 }
 
-// NoOpTCPMetricsCollector is a [TCPMetricsCollector] that doesn't do anything. Useful in tests
+// NoOpTCPMetrics is a [TCPMetrics] that doesn't do anything. Useful in tests
 // or if you don't want to track metrics.
-type NoOpTCPMetricsCollector struct{}
+type NoOpTCPMetrics struct{}
 
-var _ TCPMetricsCollector = (*NoOpTCPMetricsCollector)(nil)
+var _ TCPMetrics = (*NoOpTCPMetrics)(nil)
 
-func (m *NoOpTCPMetricsCollector) AddClosedTCPConnection(clientAddr net.Addr, accessKey string, status string, data metrics.ProxyMetrics, duration time.Duration) {
+func (m *NoOpTCPMetrics) AddClosedTCPConnection(clientAddr net.Addr, accessKey string, status string, data metrics.ProxyMetrics, duration time.Duration) {
 }
-func (m *NoOpTCPMetricsCollector) AddOpenTCPConnection(clientAddr net.Addr) {}
-func (m *NoOpTCPMetricsCollector) AddAuthenticatedTCPConnection(clientAddr net.Addr, accessKey string) {
+func (m *NoOpTCPMetrics) AddOpenTCPConnection(clientAddr net.Addr) {}
+func (m *NoOpTCPMetrics) AddAuthenticatedTCPConnection(clientAddr net.Addr, accessKey string) {
 }
-func (m *NoOpTCPMetricsCollector) AddTCPProbe(status, drainResult string, listenerId string, clientProxyBytes int64) {
+func (m *NoOpTCPMetrics) AddTCPProbe(status, drainResult string, listenerId string, clientProxyBytes int64) {
 }
-func (m *NoOpTCPMetricsCollector) AddTCPCipherSearch(accessKeyFound bool, timeToCipher time.Duration) {
+func (m *NoOpTCPMetrics) AddTCPCipherSearch(accessKeyFound bool, timeToCipher time.Duration) {
 }

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
-	"github.com/Jigsaw-Code/outline-ss-server/ipinfo"
 	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	logging "github.com/op/go-logging"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
@@ -215,40 +214,38 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 }
 
 // Stub metrics implementation for testing replay defense.
-type probeTestMetrics struct {
+type probeTestMetricsCollector struct {
 	mu          sync.Mutex
 	probeData   []int64
 	probeStatus []string
 	closeStatus []string
 }
 
-var _ TCPMetrics = (*probeTestMetrics)(nil)
+var _ TCPMetricsCollector = (*probeTestMetricsCollector)(nil)
 
-func (m *probeTestMetrics) AddClosedTCPConnection(clientInfo ipinfo.IPInfo, clientAddr net.Addr, accessKey string, status string, data metrics.ProxyMetrics, duration time.Duration) {
+func (m *probeTestMetricsCollector) AddClosedTCPConnection(clientAddr net.Addr, accessKey string, status string, data metrics.ProxyMetrics, duration time.Duration) {
 	m.mu.Lock()
 	m.closeStatus = append(m.closeStatus, status)
 	m.mu.Unlock()
 }
 
-func (m *probeTestMetrics) GetIPInfo(net.IP) (ipinfo.IPInfo, error) {
-	return ipinfo.IPInfo{}, nil
-}
-func (m *probeTestMetrics) AddOpenTCPConnection(clientInfo ipinfo.IPInfo) {
+func (m *probeTestMetricsCollector) AddOpenTCPConnection(clientAddr net.Addr) {
 }
 
-func (m *probeTestMetrics) AddAuthenticatedTCPConnection(clientAddr net.Addr, accessKey string) {
+func (m *probeTestMetricsCollector) AddAuthenticatedTCPConnection(clientAddr net.Addr, accessKey string) {
 }
 
-func (m *probeTestMetrics) AddTCPProbe(status, drainResult string, listenerId string, clientProxyBytes int64) {
+func (m *probeTestMetricsCollector) AddTCPProbe(status, drainResult string, listenerId string, clientProxyBytes int64) {
 	m.mu.Lock()
 	m.probeData = append(m.probeData, clientProxyBytes)
 	m.probeStatus = append(m.probeStatus, status)
 	m.mu.Unlock()
 }
 
-func (m *probeTestMetrics) AddTCPCipherSearch(accessKeyFound bool, timeToCipher time.Duration) {}
+func (m *probeTestMetricsCollector) AddTCPCipherSearch(accessKeyFound bool, timeToCipher time.Duration) {
+}
 
-func (m *probeTestMetrics) countStatuses() map[string]int {
+func (m *probeTestMetricsCollector) countStatuses() map[string]int {
 	counts := make(map[string]int)
 	for _, status := range m.closeStatus {
 		counts[status] = counts[status] + 1
@@ -279,7 +276,7 @@ func TestProbeRandom(t *testing.T) {
 	listener := makeLocalhostListener(t)
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, 200*time.Millisecond)
 	done := make(chan struct{})
@@ -356,7 +353,7 @@ func TestProbeClientBytesBasicTruncated(t *testing.T) {
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, 200*time.Millisecond)
 	handler.SetTargetDialer(makeValidatingTCPStreamDialer(allowAll))
@@ -391,7 +388,7 @@ func TestProbeClientBytesBasicModified(t *testing.T) {
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, 200*time.Millisecond)
 	handler.SetTargetDialer(makeValidatingTCPStreamDialer(allowAll))
@@ -427,7 +424,7 @@ func TestProbeClientBytesCoalescedModified(t *testing.T) {
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, 200*time.Millisecond)
 	handler.SetTargetDialer(makeValidatingTCPStreamDialer(allowAll))
@@ -470,7 +467,7 @@ func TestProbeServerBytesModified(t *testing.T) {
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
 	cipher := firstCipher(cipherList)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, 200*time.Millisecond)
 	done := make(chan struct{})
@@ -500,7 +497,7 @@ func TestReplayDefense(t *testing.T) {
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
 	replayCache := NewReplayCache(5)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	const testTimeout = 200 * time.Millisecond
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, &replayCache, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, testTimeout)
@@ -579,7 +576,7 @@ func TestReverseReplayDefense(t *testing.T) {
 	cipherList, err := MakeTestCiphers(makeTestSecrets(1))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
 	replayCache := NewReplayCache(5)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	const testTimeout = 200 * time.Millisecond
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, &replayCache, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, testTimeout)
@@ -651,7 +648,7 @@ func probeExpectTimeout(t *testing.T, payloadSize int) {
 	listener := makeLocalhostListener(t)
 	cipherList, err := MakeTestCiphers(makeTestSecrets(5))
 	require.NoError(t, err, "MakeTestCiphers failed: %v", err)
-	testMetrics := &probeTestMetrics{}
+	testMetrics := &probeTestMetricsCollector{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, testMetrics)
 	handler := NewTCPHandler(authFunc, testMetrics, testTimeout)
 


### PR DESCRIPTION
This PR detangles the Prometheus metrics from the service handlers. `TCPMetrics` does not need to embed `ipinfo.IPInfoMap`; that's an implementation detail. Our implementation of `TCPMetrics` just happens to use IPInfoMap to log metrics to Prometheus with `IPInfo` labels, but it shouldn't be a requirement of the service handlers.

This also revamps the `outlineMetricsCollector` type not to need a `prometheus.Registerer`. Instead, it implements the `prometheus.Collector` interface, so that `main()` can create the collector and then register it.

TODO:
- [ ] Refactor `getIPInfoFromAddr()` to delete entries from `m.ipInfos`, maybe with a TTL?