### PR TITLE
feat: add AS organization name to metrics

### DIFF
--- a/cmd/outline-ss-server/metrics_test.go
+++ b/cmd/outline-ss-server/metrics_test.go
@@ -58,7 +58,7 @@ func TestMethodsDontPanic(t *testing.T) {
 		TargetProxy: 3,
 		ProxyClient: 4,
 	}
-	ipInfo := ipinfo.IPInfo{CountryCode: "US", ASN: 100}
+	ipInfo := ipinfo.IPInfo{CountryCode: "US", ASN: ipinfo.ASN{Number: 100}}
 	ssMetrics.SetBuildInfo("0.0.0-test")
 	ssMetrics.SetNumAccessKeys(20, 2)
 	ssMetrics.AddOpenTCPConnection(ipInfo)
@@ -74,8 +74,8 @@ func TestMethodsDontPanic(t *testing.T) {
 }
 
 func TestASNLabel(t *testing.T) {
-	require.Equal(t, "", asnLabel(0))
-	require.Equal(t, "100", asnLabel(100))
+	require.Equal(t, "", asnLabel(ipinfo.ASN{Number: 0}))
+	require.Equal(t, "100", asnLabel(ipinfo.ASN{Number: 100}))
 }
 
 func TestTunnelTime(t *testing.T) {
@@ -113,7 +113,7 @@ func TestTunnelTime(t *testing.T) {
 		expected := strings.NewReader(`
 		# HELP tunnel_time_seconds_per_location Tunnel time, per location.
 		# TYPE tunnel_time_seconds_per_location counter
-		tunnel_time_seconds_per_location{asn="",location="XL"} 5
+		tunnel_time_seconds_per_location{asn="",asorg="",location="XL"} 5
 	`)
 		err := promtest.GatherAndCompare(
 			reg,
@@ -140,7 +140,7 @@ func TestTunnelTimePerKeyDoesNotPanicOnUnknownClosedConnection(t *testing.T) {
 
 func BenchmarkOpenTCP(b *testing.B) {
 	ssMetrics := newPrometheusOutlineMetrics(nil)
-	ipinfo := ipinfo.IPInfo{CountryCode: "US", ASN: 100}
+	ipinfo := ipinfo.IPInfo{CountryCode: "US", ASN: ipinfo.ASN{Number: 100}}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ssMetrics.AddOpenTCPConnection(ipinfo)
@@ -149,7 +149,7 @@ func BenchmarkOpenTCP(b *testing.B) {
 
 func BenchmarkCloseTCP(b *testing.B) {
 	ssMetrics := newPrometheusOutlineMetrics(nil)
-	ipinfo := ipinfo.IPInfo{CountryCode: "US", ASN: 100}
+	ipinfo := ipinfo.IPInfo{CountryCode: "US", ASN: ipinfo.ASN{Number: 100}}
 	addr := fakeAddr("127.0.0.1:9")
 	accessKey := "key 1"
 	status := "OK"
@@ -177,7 +177,7 @@ func BenchmarkProbe(b *testing.B) {
 
 func BenchmarkClientUDP(b *testing.B) {
 	ssMetrics := newPrometheusOutlineMetrics(nil)
-	clientInfo := ipinfo.IPInfo{CountryCode: "ZZ", ASN: 100}
+	clientInfo := ipinfo.IPInfo{CountryCode: "ZZ", ASN: ipinfo.ASN{Number: 100}}
 	accessKey := "key 1"
 	status := "OK"
 	size := 1000
@@ -191,7 +191,7 @@ func BenchmarkClientUDP(b *testing.B) {
 
 func BenchmarkTargetUDP(b *testing.B) {
 	ssMetrics := newPrometheusOutlineMetrics(nil)
-	clientInfo := ipinfo.IPInfo{CountryCode: "ZZ", ASN: 100}
+	clientInfo := ipinfo.IPInfo{CountryCode: "ZZ", ASN: ipinfo.ASN{Number: 100}}
 	accessKey := "key 1"
 	status := "OK"
 	size := 1000

--- a/cmd/outline-ss-server/metrics_test.go
+++ b/cmd/outline-ss-server/metrics_test.go
@@ -74,8 +74,8 @@ func TestMethodsDontPanic(t *testing.T) {
 }
 
 func TestASNLabel(t *testing.T) {
-	require.Equal(t, "", asnLabel(ipinfo.ASN{Number: 0}))
-	require.Equal(t, "100", asnLabel(ipinfo.ASN{Number: 100}))
+	require.Equal(t, "", asnLabel(0))
+	require.Equal(t, "100", asnLabel(100))
 }
 
 func TestTunnelTime(t *testing.T) {

--- a/ipinfo/ipinfo.go
+++ b/ipinfo/ipinfo.go
@@ -26,13 +26,18 @@ type IPInfoMap interface {
 
 type IPInfo struct {
 	CountryCode CountryCode
-	ASN         int
+	ASN         ASN
 }
 
 type CountryCode string
 
 func (cc CountryCode) String() string {
 	return string(cc)
+}
+
+type ASN struct {
+	Number       int
+	Organization string
 }
 
 const (

--- a/ipinfo/mmdb.go
+++ b/ipinfo/mmdb.go
@@ -79,7 +79,10 @@ func (ip2info *MMDBIPInfoMap) GetIPInfo(ip net.IP) (IPInfo, error) {
 		if asnErr != nil {
 			asnErr = fmt.Errorf("asn lookup failed: %w", asnErr)
 		} else if record != nil {
-			info.ASN = int(record.AutonomousSystemNumber)
+			info.ASN = ASN{
+				Number:       int(record.AutonomousSystemNumber),
+				Organization: record.AutonomousSystemOrganization,
+			}
 		}
 	}
 	return info, errors.Join(countryErr, asnErr)

--- a/ipinfo/mmdb_test.go
+++ b/ipinfo/mmdb_test.go
@@ -78,11 +78,11 @@ func TestIPInfoMapASNOnly(t *testing.T) {
 	// For examples, see https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-ASN-Test.json
 	info, err := ip2info.GetIPInfo(net.ParseIP("38.108.80.24"))
 	require.NoError(t, err)
-	assert.Equal(t, IPInfo{ASN: 174}, info)
+	assert.Equal(t, IPInfo{ASN: ASN{Number: 174, Organization: "Cogent Communications"}}, info)
 
 	info, err = ip2info.GetIPInfo(net.ParseIP("2400::1"))
 	require.NoError(t, err)
-	assert.Equal(t, IPInfo{ASN: 4766}, info)
+	assert.Equal(t, IPInfo{ASN: ASN{Number: 4766, Organization: "Korea Telecom"}}, info)
 
 	info, err = ip2info.GetIPInfo(net.ParseIP("10.0.0.1"))
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestIPInfoMap(t *testing.T) {
 
 	info, err := ip2info.GetIPInfo(net.ParseIP("67.43.156.0"))
 	require.NoError(t, err)
-	assert.Equal(t, IPInfo{CountryCode: "BT", ASN: 35908}, info)
+	assert.Equal(t, IPInfo{CountryCode: "BT", ASN: ASN{Number: 35908, Organization: ""}}, info)
 
 	info, err = ip2info.GetIPInfo(net.ParseIP("2a02:d280::"))
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestIPInfoMap(t *testing.T) {
 
 	info, err = ip2info.GetIPInfo(net.ParseIP("2400::1"))
 	require.NoError(t, err)
-	assert.Equal(t, IPInfo{ASN: 4766}, info)
+	assert.Equal(t, IPInfo{ASN: ASN{Number: 4766, Organization: "Korea Telecom"}}, info)
 
 	info, err = ip2info.GetIPInfo(net.ParseIP("10.0.0.1"))
 	require.NoError(t, err)


### PR DESCRIPTION
I don't particularly like the name `asorg` but I also can't think of anything better. @fortuna Any suggestions?