### PR TITLE
chore: support Go workspaces

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
         git submodule update --init
 
     - name: Build
-      run: go build -v ./...
+      run: GOWORK=off go build -v ./...
 
     - name: Test
       run: go test -race -benchmem -bench=. ./... -benchtime=100ms

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@
 
 # Go task
 /.task/
+
+# Go workspace
+go.work
+go.work.sum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
     main: ./cmd/outline-ss-server
     env:
       - CGO_ENABLED=0
+      - GOWORK=off
     goos:
       - darwin
       - windows


### PR DESCRIPTION
This makes it easier to work with multiple modules locally, e.g. with local forks.