### PR TITLE
refactor: use a noop metric implementation if no metrics are provided

### DIFF
--- a/internal/integration_test/integration_test.go
+++ b/internal/integration_test/integration_test.go
@@ -130,6 +130,7 @@ func TestTCPEcho(t *testing.T) {
 	}
 	replayCache := service.NewReplayCache(5)
 	const testTimeout = 200 * time.Millisecond
+	testMetrics := &statusMetrics{}
 	authFunc := service.NewShadowsocksStreamAuthenticator(cipherList, &replayCache, &fakeShadowsocksMetrics{})
 	handler := service.NewStreamHandler(authFunc, testTimeout)
 	handler.SetTargetDialer(&transport.TCPDialer{})
@@ -137,7 +138,7 @@ func TestTCPEcho(t *testing.T) {
 	go func() {
 		service.StreamServe(
 			func() (transport.StreamConn, error) { return proxyListener.AcceptTCP() },
-			func(ctx context.Context, conn transport.StreamConn) { handler.Handle(ctx, conn, nil) },
+			func(ctx context.Context, conn transport.StreamConn) { handler.Handle(ctx, conn, testMetrics) },
 		)
 		done <- struct{}{}
 	}()
@@ -191,14 +192,11 @@ func (m *fakeShadowsocksMetrics) AddCipherSearch(accessKeyFound bool, timeToCiph
 }
 
 type statusMetrics struct {
+	service.NoOpTCPConnMetrics
 	sync.Mutex
 	statuses []string
 }
 
-var _ service.TCPConnMetrics = (*statusMetrics)(nil)
-
-func (m *statusMetrics) AddAuthenticated(accessKey string) {}
-func (m *statusMetrics) AddProbe(status, drainResult string, clientProxyBytes int64) {}
 func (m *statusMetrics) AddClosed(status string, data metrics.ProxyMetrics, duration time.Duration) {
 	m.Lock()
 	m.statuses = append(m.statuses, status)
@@ -401,6 +399,7 @@ func BenchmarkTCPThroughput(b *testing.B) {
 		b.Fatal(err)
 	}
 	const testTimeout = 200 * time.Millisecond
+	testMetrics := &service.NoOpTCPConnMetrics{}
 	authFunc := service.NewShadowsocksStreamAuthenticator(cipherList, nil, &fakeShadowsocksMetrics{})
 	handler := service.NewStreamHandler(authFunc, testTimeout)
 	handler.SetTargetDialer(&transport.TCPDialer{})
@@ -408,7 +407,7 @@ func BenchmarkTCPThroughput(b *testing.B) {
 	go func() {
 		service.StreamServe(
 			service.WrapStreamAcceptFunc(proxyListener.AcceptTCP),
-			func(ctx context.Context, conn transport.StreamConn) { handler.Handle(ctx, conn, nil) },
+			func(ctx context.Context, conn transport.StreamConn) { handler.Handle(ctx, conn, testMetrics) },
 		)
 		done <- struct{}{}
 	}()
@@ -467,6 +466,7 @@ func BenchmarkTCPMultiplexing(b *testing.B) {
 	}
 	replayCache := service.NewReplayCache(service.MaxCapacity)
 	const testTimeout = 200 * time.Millisecond
+	testMetrics := &service.NoOpTCPConnMetrics{}
 	authFunc := service.NewShadowsocksStreamAuthenticator(cipherList, &replayCache, &fakeShadowsocksMetrics{})
 	handler := service.NewStreamHandler(authFunc, testTimeout)
 	handler.SetTargetDialer(&transport.TCPDialer{})
@@ -474,7 +474,7 @@ func BenchmarkTCPMultiplexing(b *testing.B) {
 	go func() {
 		service.StreamServe(
 			service.WrapStreamAcceptFunc(proxyListener.AcceptTCP),
-			func(ctx context.Context, conn transport.StreamConn) { handler.Handle(ctx, conn, nil) },
+			func(ctx context.Context, conn transport.StreamConn) { handler.Handle(ctx, conn, testMetrics) },
 		)
 		done <- struct{}{}
 	}()

--- a/service/shadowsocks.go
+++ b/service/shadowsocks.go
@@ -20,3 +20,12 @@ import "time"
 type ShadowsocksConnMetrics interface {
 	AddCipherSearch(accessKeyFound bool, timeToCipher time.Duration)
 }
+
+// NoOpShadowsocksConnMetrics is a [ShadowsocksConnMetrics] that doesn't do anything. Useful in tests
+// or if you don't want to track metrics.
+type NoOpShadowsocksConnMetrics struct{}
+
+var _ ShadowsocksConnMetrics = (*NoOpShadowsocksConnMetrics)(nil)
+
+func (m *NoOpShadowsocksConnMetrics) AddCipherSearch(accessKeyFound bool, timeToCipher time.Duration) {
+}

--- a/service/tcp.go
+++ b/service/tcp.go
@@ -117,6 +117,9 @@ type StreamAuthenticateFunc func(clientConn transport.StreamConn) (string, trans
 // NewShadowsocksStreamAuthenticator creates a stream authenticator that uses Shadowsocks.
 // TODO(fortuna): Offer alternative transports.
 func NewShadowsocksStreamAuthenticator(ciphers CipherList, replayCache *ReplayCache, metrics ShadowsocksConnMetrics) StreamAuthenticateFunc {
+	if metrics == nil {
+		metrics = &NoOpShadowsocksConnMetrics{}
+	}
 	return func(clientConn transport.StreamConn) (string, transport.StreamConn, *onet.ConnectionError) {
 		// Find the cipher and acess key id.
 		cipherEntry, clientReader, clientSalt, timeToCipher, keyErr := findAccessKey(clientConn, remoteIP(clientConn), ciphers)

--- a/service/udp.go
+++ b/service/udp.go
@@ -308,13 +308,11 @@ type natmap struct {
 	running *sync.WaitGroup
 }
 
-func newNATmap(timeout time.Duration, metrics UDPMetrics, running *sync.WaitGroup) *natmap {
-	return &natmap{
-		metrics: metrics,
-		running: running,
-		keyConn: make(map[string]*natconn),
-		timeout: timeout,
-	}
+func newNATmap(timeout time.Duration, sm UDPMetrics, running *sync.WaitGroup) *natmap {
+	m := &natmap{metrics: sm, running: running}
+	m.keyConn = make(map[string]*natconn)
+	m.timeout = timeout
+	return m
 }
 
 func (m *natmap) Get(key string) *natconn {

--- a/service/udp.go
+++ b/service/udp.go
@@ -92,11 +92,14 @@ func NewPacketHandler(natTimeout time.Duration, cipherList CipherList, m UDPMetr
 	if m == nil {
 		m = &NoOpUDPMetrics{}
 	}
+	if ssMetrics == nil {
+		ssMetrics = &NoOpShadowsocksConnMetrics{}
+	}
 	return &packetHandler{
-		natTimeout: natTimeout,
-		ciphers: cipherList,
-		m: m,
-		ssm: ssMetrics,
+		natTimeout:        natTimeout,
+		ciphers:           cipherList,
+		m:                 m,
+		ssm:               ssMetrics,
 		targetIPValidator: onet.RequirePublicIP,
 	}
 }


### PR DESCRIPTION
There are currently many NULL pointer exception issues because we never verify that the provided metrics are not NULL. If no metrics are provided, we use noop metric implementations.