### PR TITLE
fix: prevent data corruption in `multiPacketListener` by avoiding buffer resizing

### DIFF
--- a/service/listeners.go
+++ b/service/listeners.go
@@ -288,10 +288,10 @@ func (m *multiPacketListener) Acquire() (net.PacketConn, error) {
 			buffer := make([]byte, serverUDPBufferSize)
 			for {
 				n, addr, err := m.pc.ReadFrom(buffer)
-				buffer = buffer[:n]
+				pkt := buffer[:n]
 				select {
 				case req := <-m.readCh:
-					n := copy(req.buffer, buffer)
+					n := copy(req.buffer, pkt)
 					req.respCh <- struct {
 						n    int
 						addr net.Addr

--- a/service/listeners_test.go
+++ b/service/listeners_test.go
@@ -157,7 +157,7 @@ func TestMultiPacketListener_SequentialReads(t *testing.T) {
 	n1, _, err := conn.ReadFrom(received1)
 	require.NoError(t, err)
 
-	// Send and receive a second larger datagram.
+	// Send and receive a second larger packet.
 	data2 := []byte("a longer message than the first one")
 	_, err = udpConn.Write(data2)
 	require.NoError(t, err)

--- a/service/listeners_test.go
+++ b/service/listeners_test.go
@@ -142,6 +142,33 @@ func TestListenerManagerPacketListenerCreatesListenerOnDemand(t *testing.T) {
 	<-done
 }
 
+func TestMultiPacketListener_SequentialReads(t *testing.T) {
+	m := NewListenerManager()
+	conn, err := m.ListenPacket("127.0.0.1:0")
+	require.NoError(t, err)
+	udpConn, err := net.Dial("udp", conn.LocalAddr().String())
+	require.NoError(t, err)
+
+	// Send and receive the first packet.
+	data1 := []byte("hello")
+	_, err = udpConn.Write(data1)
+	require.NoError(t, err)
+	received1 := make([]byte, serverUDPBufferSize)
+	n1, _, err := conn.ReadFrom(received1)
+	require.NoError(t, err)
+
+	// Send and receive a second larger datagram.
+	data2 := []byte("a longer message than the first one")
+	_, err = udpConn.Write(data2)
+	require.NoError(t, err)
+	received2 := make([]byte, serverUDPBufferSize)
+	n2, _, err := conn.ReadFrom(received2)
+	require.NoError(t, err)
+
+	require.Equal(t, string(data1), string(received1[:n1]))
+	require.Equal(t, string(data2), string(received2[:n2]))
+}
+
 func BenchmarkMultiStreamListener_Acquire(b *testing.B) {
 	lm := NewListenerManager()
 


### PR DESCRIPTION
The `multiPacketListener` suffered from data corruption due to improper handling of the shared read buffer, resizing the shared read buffer after each read. This resizing could lead to data corruption when subsequent reads involved larger packets.

This commit resolves the issue by avoiding resizing of the original buffer. Instead, a new slice is created to represent the received data, ensuring that the buffer remains at its original size.