### PR TITLE
fix: do not set the host address

### DIFF
--- a/cmd/outline-ss-server/main.go
+++ b/cmd/outline-ss-server/main.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -212,7 +211,10 @@ func (s *OutlineServer) runConfig(config Config) (func() error, error) {
 				cipherList.PushBack(&entry)
 			}
 			for portNum, cipherList := range portCiphers {
-				addr := net.JoinHostPort("::", strconv.Itoa(portNum))
+				// NOTE: We explicitly construct the address string with only the port
+				// number. This will result in an address that listens on all available
+				// network interfaces (both IPv4 and IPv6).
+				addr := fmt.Sprintf(":%d", portNum)
 
 				ciphers := service.NewCipherList()
 				ciphers.Update(cipherList)


### PR DESCRIPTION
This was a regression introduced in #192, which was rolled out in outline-server v1.10.0 released last week and caused issues for users using machines with IPv6 disabled: https://github.com/Jigsaw-Code/outline-server/issues/1601.

I'm unable to reproduce the issue itself when IPv6 is disabled on my corp or DigitalOcean machines, but that may be specific to those machines.