### PR TITLE
fix: use correct tag when commit is tagged with both prerelease and release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,9 @@ changelog:
     - '^test:'
 
 git:
+  # Sort tags by creation time when commit has more than one tag.
+  tag_sort: -version:creatordate
+
   # Specify prerelease suffix while sorting tags if there are more than one tag
   # in the same commit.
   prerelease_suffix: "-rc"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,8 @@ builds:
         goarch: 386
 
 archives:
-  -
+  - name_template: >-
+      {{ .ProjectName }}_{{ index (split .Version "-rc") 0 }}_{{ .Os }}_{{ .Arch }}"
     replacements:
       darwin: macos
       386: i386
@@ -63,3 +64,8 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+
+git:
+  # Specify prerelease suffix while sorting tags if there are more than one tag
+  # in the same commit.
+  prerelease_suffix: "-rc"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,8 +39,7 @@ builds:
         goarch: 386
 
 archives:
-  - name_template: >-
-      {{ .ProjectName }}_{{ index (split .Version "-rc") 0 }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+  -
     replacements:
       darwin: macos
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ builds:
 
 archives:
   - name_template: >-
-      {{ .ProjectName }}_{{ index (split .Version "-rc") 0 }}_{{ .Os }}_{{ .Arch }}"
+      {{ .ProjectName }}_{{ index (split .Version "-rc") 0 }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     replacements:
       darwin: macos
       386: i386

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,20 +23,14 @@ tasks:
   release:
     desc: "Release"
     deps: [clean]
-    vars:
-      RELEASE_TAG:
-        sh: echo "{{.TAG}}" | sed -E "s/-rc.+$//"
     cmds:
-      - GORELEASER_CURRENT_TAG={{.RELEASE_TAG}} go run github.com/goreleaser/goreleaser
+      - go run github.com/goreleaser/goreleaser
 
 
   release-local:
     desc: "Build a release binary"
-    vars:
-      RELEASE_TAG:
-        sh: echo "{{.TAG}}" | sed -E "s/-rc.+$//"
     cmds:
-      - GORELEASER_CURRENT_TAG={{.RELEASE_TAG}} go run github.com/goreleaser/goreleaser --clean --snapshot
+      - go run github.com/goreleaser/goreleaser --clean --snapshot
 
   test:
     desc: "Runs tests"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,14 +23,20 @@ tasks:
   release:
     desc: "Release"
     deps: [clean]
+    vars:
+      RELEASE_TAG:
+        sh: echo "{{.TAG}}" | sed -E "s/-rc.+$//"
     cmds:
-      - go run github.com/goreleaser/goreleaser
+      - GORELEASER_CURRENT_TAG={{.RELEASE_TAG}} go run github.com/goreleaser/goreleaser
 
 
   release-local:
     desc: "Build a release binary"
+    vars:
+      RELEASE_TAG:
+        sh: echo "{{.TAG}}" | sed -E "s/-rc.+$//"
     cmds:
-      - go run github.com/goreleaser/goreleaser --clean --snapshot
+      - GORELEASER_CURRENT_TAG={{.RELEASE_TAG}} go run github.com/goreleaser/goreleaser --clean --snapshot
 
   test:
     desc: "Runs tests"


### PR DESCRIPTION
Add a [Git config specification](https://goreleaser.com/customization/git/) to make `goreleaser` find the latest tag for a specific release, following [this advice](https://github.com/orgs/goreleaser/discussions/3732).

When you run `goreleaser` on a non-rc tag, the corresponding commit will always have 2 tags (the `vX.X.X-rcY` and `vX.X.X` tags) and `goreleaser` seems to be picking the wrong one, which puts the `-rc` variant first. This prevents someone from checking out the `vX.X.X` tag and running `goreleaser`.