### PR TITLE
fix(config): allow empty IP and be strict on ports

### DIFF
--- a/cmd/outline-ss-server/config.go
+++ b/cmd/outline-ss-server/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -228,12 +229,23 @@ func (c *Config) validate() error {
 }
 
 func validateAddress(addr string) error {
-	host, _, err := net.SplitHostPort(addr)
+	host, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
 		return err
 	}
-	if ip := net.ParseIP(host); ip == nil {
-		return fmt.Errorf("address must be IP, found: %s", host)
+	if host != "" {
+		if ip := net.ParseIP(host); ip == nil {
+			return fmt.Errorf("address must be IP, found: %s", host)
+		}
+	}
+	if portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return fmt.Errorf("invalid port: %s", portStr)
+		}
+		if port < 0 || port > 65535 {
+			return fmt.Errorf("port out of range: %d", port)
+		}
 	}
 	return nil
 }

--- a/cmd/outline-ss-server/config.go
+++ b/cmd/outline-ss-server/config.go
@@ -233,6 +233,9 @@ func validateAddress(addr string) error {
 	if err != nil {
 		return err
 	}
+	// NOTE: We allow addresses with only the port number set . This will result
+	// in an address that listens on all available network interfaces (both IPv4
+	// and IPv6).
 	if host != "" {
 		if ip := net.ParseIP(host); ip == nil {
 			return fmt.Errorf("address must be IP, found: %s", host)

--- a/cmd/outline-ss-server/config_test.go
+++ b/cmd/outline-ss-server/config_test.go
@@ -165,6 +165,8 @@ services:
   - listeners:
       - type: tcp
         address: "[::]:9000"
+      - type: udp
+        address: ":9000"
       - type: websocket-stream
         web_server: my_web_server
         path: "/tcp"


### PR DESCRIPTION
The `outline-server` using the new service config will want to use no IP to avoid forcing IPv6.

This is similar to https://github.com/Jigsaw-Code/outline-ss-server/commit/d240aa19d895910a85bd5d5d2bfc92cae4e98396 but for the new service config format. Context for that was in https://github.com/Jigsaw-Code/outline-server/issues/1601.