### PR TITLE
fix: return early on failure to upgrade

### DIFF
--- a/cmd/outline-ss-server/main.go
+++ b/cmd/outline-ss-server/main.go
@@ -344,6 +344,7 @@ func (s *OutlineServer) runConfig(config Config) (func() error, error) {
 							conn, err := websocket.Upgrade(w, r, nil)
 							if err != nil {
 								slog.Error("failed to upgrade", "err", err)
+								return
 							}
 							defer conn.Close()
 							// RemoteAddr is "IP:port" for direct connections, but may be just "IP" when proxied.
@@ -364,6 +365,7 @@ func (s *OutlineServer) runConfig(config Config) (func() error, error) {
 							conn, err := websocket.Upgrade(w, r, nil)
 							if err != nil {
 								slog.Error("failed to upgrade", "err", err)
+								return
 							}
 							defer conn.Close()
 							// RemoteAddr is "IP:port" for direct connections, but may be just "IP" when proxied.


### PR DESCRIPTION
Fixes #239. Without this, the server panics on non-WebSockets requests.

Before: 

```sh
$ curl http://localhost:8000/SECRET/tcp
curl: (52) Empty reply from server
```

After:

```sh
$ curl http://localhost:8000/SECRET/tcp
Bad Request
```