### PR TITLE
chore: upgrade `outline-sdk/x`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Jigsaw-Code/outline-ss-server
 
 require (
 	github.com/Jigsaw-Code/outline-sdk v0.0.18-0.20241106233708-faffebb12629
-	github.com/Jigsaw-Code/outline-sdk/x v0.0.0-20250204151340-93ebcb07dba9
+	github.com/Jigsaw-Code/outline-sdk/x v0.0.2-0.20250304133713-52f1a365e5ed
 	github.com/go-task/task/v3 v3.34.1
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/addlicense v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -530,6 +530,10 @@ github.com/Jigsaw-Code/outline-sdk v0.0.18-0.20241106233708-faffebb12629 h1:sHi1
 github.com/Jigsaw-Code/outline-sdk v0.0.18-0.20241106233708-faffebb12629/go.mod h1:CFDKyGZA4zatKE4vMLe8TyQpZCyINOeRFbMAmYHxodw=
 github.com/Jigsaw-Code/outline-sdk/x v0.0.0-20250204151340-93ebcb07dba9 h1:GKvH8vGir6MbJmWZfh/zNlBKl5z4TxCsfDnn8eHghMk=
 github.com/Jigsaw-Code/outline-sdk/x v0.0.0-20250204151340-93ebcb07dba9/go.mod h1:aFUEz6Z/eD0NS3c3fEIX+JO2D9aIrXCmWTb1zJFlItw=
+github.com/Jigsaw-Code/outline-sdk/x v0.0.1 h1:DW8Ja4iWKPqYpnahBXQ/eg1WVDw/F3Pktbz1mBWTZXw=
+github.com/Jigsaw-Code/outline-sdk/x v0.0.1/go.mod h1:aFUEz6Z/eD0NS3c3fEIX+JO2D9aIrXCmWTb1zJFlItw=
+github.com/Jigsaw-Code/outline-sdk/x v0.0.2-0.20250304133713-52f1a365e5ed h1:NfybsWzXQLPNueDsoPJMmvw/i7hWXqk9xaoA9X1cGgM=
+github.com/Jigsaw-Code/outline-sdk/x v0.0.2-0.20250304133713-52f1a365e5ed/go.mod h1:aFUEz6Z/eD0NS3c3fEIX+JO2D9aIrXCmWTb1zJFlItw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=


### PR DESCRIPTION
Pulling in fix from https://github.com/Jigsaw-Code/outline-sdk/commit/59218bdd65c08beb5f94b6232f6323c6c178371d.