### PR TITLE
Fix UDP association packet buffer leaks

### DIFF
--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -254,6 +254,12 @@ func (m *probeTestMetrics) AddProbe(status, drainResult string, clientProxyBytes
 func (m *probeTestMetrics) AddCipherSearch(accessKeyFound bool, timeToCipher time.Duration) {
 }
 
+func (m *probeTestMetrics) snapshot() (probeData []int64, probeStatus []string, closeStatus []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]int64(nil), m.probeData...), append([]string(nil), m.probeStatus...), append([]string(nil), m.closeStatus...)
+}
+
 func (m *probeTestMetrics) countStatuses() map[string]int {
 	counts := make(map[string]int)
 	for _, status := range m.closeStatus {
@@ -633,29 +639,43 @@ func TestReverseReplayDefense(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, err := conn.Write(preamble)
+	tcpConn, ok := conn.(*net.TCPConn)
+	if !ok {
+		t.Fatalf("expected *net.TCPConn, got %T", conn)
+	}
+	n, err := tcpConn.Write(preamble)
 	if n < len(preamble) {
 		t.Error(err)
 	}
-	conn.Close()
+	// Wait for the proxy to finish processing this connection before stopping the listener.
+	tcpConn.CloseWrite()
+	tcpConn.Read(make([]byte, 1))
+	tcpConn.Close()
 	listener.Close()
 	<-done
 
+	require.Eventually(t, func() bool {
+		_, _, closeStatus := testMetrics.snapshot()
+		return len(closeStatus) == 1
+	}, testTimeout, 10*time.Millisecond, "Replay should have reported an error status")
+
+	probeData, probeStatus, closeStatus := testMetrics.snapshot()
+
 	// The preamble should have been marked as a server replay.
-	if len(testMetrics.probeData) == 1 {
-		clientProxyData := testMetrics.probeData[0]
+	if len(probeData) == 1 {
+		clientProxyData := probeData[0]
 		if clientProxyData != int64(len(preamble)) {
 			t.Errorf("Unexpected probe data: %v", clientProxyData)
 		}
-		status := testMetrics.probeStatus[0]
+		status := probeStatus[0]
 		if status != "ERR_REPLAY_SERVER" {
 			t.Errorf("Unexpected TCP probe status: %s", status)
 		}
 	} else {
 		t.Error("Replay should have triggered probe detection")
 	}
-	if len(testMetrics.closeStatus) == 1 {
-		status := testMetrics.closeStatus[0]
+	if len(closeStatus) == 1 {
+		status := closeStatus[0]
 		if status != "ERR_REPLAY_SERVER" {
 			t.Errorf("Unexpected TCP close status: %s", status)
 		}

--- a/service/udp.go
+++ b/service/udp.go
@@ -177,14 +177,16 @@ func (h *associationHandler) HandleAssociation(ctx context.Context, clientConn n
 				var keyID string
 				textLazySlice := readBufPool.LazySlice()
 				unpackStart := time.Now()
-				textData, keyID, cryptoKey, err = findAccessKeyUDP(ip, textLazySlice.Acquire(), pkt, h.ciphers, h.logger)
+				textBuf := textLazySlice.Acquire()
+				textData, keyID, cryptoKey, err = findAccessKeyUDP(ip, textBuf, pkt, h.ciphers, h.logger)
 				timeToCipher := time.Since(unpackStart)
-				textLazySlice.Release()
 				h.ssm.AddCipherSearch(err == nil, timeToCipher)
 
 				if err != nil {
+					textLazySlice.Release()
 					return onet.NewConnectionError("ERR_CIPHER", "Failed to unpack initial packet", err)
 				}
+				defer textLazySlice.Release()
 				assocMetrics.AddAuthentication(keyID)
 
 				var onetErr *onet.ConnectionError
@@ -313,7 +315,7 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 					go func() {
 						assocHandle(ctx, assoc)
 						metrics.RemoveNATEntry()
-						close(assoc.doneCh)
+						_ = assoc.Close()
 					}()
 				}
 			}
@@ -347,21 +349,23 @@ type association struct {
 	clientAddr net.Addr
 	readCh     chan *packet
 	doneCh     chan struct{}
+	closeOnce  sync.Once
 }
 
 var _ net.Conn = (*association)(nil)
 
 func (a *association) Read(p []byte) (int, error) {
-	pkt, ok := <-a.readCh
-	if !ok {
+	select {
+	case <-a.doneCh:
 		return 0, net.ErrClosed
+	case pkt := <-a.readCh:
+		n := copy(p, pkt.payload)
+		pkt.done()
+		if n < len(pkt.payload) {
+			return n, io.ErrShortBuffer
+		}
+		return n, nil
 	}
-	n := copy(p, pkt.payload)
-	pkt.done()
-	if n < len(pkt.payload) {
-		return n, io.ErrShortBuffer
-	}
-	return n, nil
 }
 
 func (a *association) Write(b []byte) (n int, err error) {
@@ -369,7 +373,11 @@ func (a *association) Write(b []byte) (n int, err error) {
 }
 
 func (a *association) Close() error {
-	close(a.readCh)
+	a.closeOnce.Do(func() {
+		if a.doneCh != nil {
+			close(a.doneCh)
+		}
+	})
 	return nil
 }
 

--- a/service/udp.go
+++ b/service/udp.go
@@ -313,7 +313,7 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 					go func() {
 						assocHandle(ctx, assoc)
 						metrics.RemoveNATEntry()
-						close(assoc.doneCh)
+						_ = assoc.Close()
 					}()
 				}
 			}
@@ -347,21 +347,23 @@ type association struct {
 	clientAddr net.Addr
 	readCh     chan *packet
 	doneCh     chan struct{}
+	closeOnce  sync.Once
 }
 
 var _ net.Conn = (*association)(nil)
 
 func (a *association) Read(p []byte) (int, error) {
-	pkt, ok := <-a.readCh
-	if !ok {
+	select {
+	case <-a.doneCh:
 		return 0, net.ErrClosed
+	case pkt := <-a.readCh:
+		n := copy(p, pkt.payload)
+		pkt.done()
+		if n < len(pkt.payload) {
+			return n, io.ErrShortBuffer
+		}
+		return n, nil
 	}
-	n := copy(p, pkt.payload)
-	pkt.done()
-	if n < len(pkt.payload) {
-		return n, io.ErrShortBuffer
-	}
-	return n, nil
 }
 
 func (a *association) Write(b []byte) (n int, err error) {
@@ -369,7 +371,11 @@ func (a *association) Write(b []byte) (n int, err error) {
 }
 
 func (a *association) Close() error {
-	close(a.readCh)
+	a.closeOnce.Do(func() {
+		if a.doneCh != nil {
+			close(a.doneCh)
+		}
+	})
 	return nil
 }
 

--- a/service/udp.go
+++ b/service/udp.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shadowsocks/go-shadowsocks2/socks"
 	"golang.getoutline.org/sdk/transport"
 	"golang.getoutline.org/sdk/transport/shadowsocks"
-	"github.com/shadowsocks/go-shadowsocks2/socks"
 
 	"golang.getoutline.org/tunnel-server/internal/slicepool"
 	onet "golang.getoutline.org/tunnel-server/net"
@@ -295,7 +295,8 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 			pkt := &packet{payload: buffer[:n], done: lazySlice.Release}
 
 			// TODO(#19): Include server address in the NAT key as well.
-			assoc := nm.Get(clientAddr.String())
+			clientAddrKey := clientAddr.String()
+			assoc := nm.Get(clientAddrKey)
 			if assoc == nil {
 				assoc = &association{
 					pc:         clientConn,
@@ -303,28 +304,34 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 					readCh:     make(chan *packet, 5),
 					doneCh:     make(chan struct{}),
 				}
-				if err != nil {
-					slog.Error("Failed to handle association", slog.Any("err", err))
-					return
-				}
-
 				var existing bool
-				assoc, existing = nm.Add(clientAddr.String(), assoc)
+				assoc, existing = nm.Add(clientAddrKey, assoc)
 				if !existing {
 					metrics.AddNATEntry()
 					go func() {
 						assocHandle(ctx, assoc)
-						metrics.RemoveNATEntry()
 						_ = assoc.Close()
+						nm.Del(clientAddrKey)
+						metrics.RemoveNATEntry()
 					}()
 				}
 			}
 			select {
 			case <-assoc.doneCh:
-				nm.Del(clientAddr.String())
-			case assoc.readCh <- pkt:
+				nm.Del(clientAddrKey)
+				pkt.done()
 			default:
+				queued, closed := assoc.enqueue(pkt)
+				if queued {
+					return
+				}
+				if closed {
+					nm.Del(clientAddrKey)
+					pkt.done()
+					return
+				}
 				slog.Debug("Dropping packet due to full read queue")
+				pkt.done()
 				// TODO: Add a metric to track number of dropped packets.
 			}
 		}()
@@ -350,6 +357,7 @@ type association struct {
 	readCh     chan *packet
 	doneCh     chan struct{}
 	closeOnce  sync.Once
+	mu         sync.Mutex
 }
 
 var _ net.Conn = (*association)(nil)
@@ -372,10 +380,40 @@ func (a *association) Write(b []byte) (n int, err error) {
 	return a.pc.WriteTo(b, a.clientAddr)
 }
 
+func (a *association) enqueue(pkt *packet) (queued bool, closed bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	select {
+	case <-a.doneCh:
+		return false, true
+	default:
+	}
+
+	select {
+	case a.readCh <- pkt:
+		return true, false
+	default:
+		return false, false
+	}
+}
+
 func (a *association) Close() error {
 	a.closeOnce.Do(func() {
 		if a.doneCh != nil {
 			close(a.doneCh)
+		}
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		for {
+			select {
+			case pkt := <-a.readCh:
+				if pkt != nil {
+					pkt.done()
+				}
+			default:
+				return
+			}
 		}
 	})
 	return nil

--- a/service/udp.go
+++ b/service/udp.go
@@ -295,7 +295,8 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 			pkt := &packet{payload: buffer[:n], done: lazySlice.Release}
 
 			// TODO(#19): Include server address in the NAT key as well.
-			assoc := nm.Get(clientAddr.String())
+			clientAddrKey := clientAddr.String()
+			assoc := nm.Get(clientAddrKey)
 			if assoc == nil {
 				assoc = &association{
 					pc:         clientConn,
@@ -309,19 +310,20 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 				}
 
 				var existing bool
-				assoc, existing = nm.Add(clientAddr.String(), assoc)
+				assoc, existing = nm.Add(clientAddrKey, assoc)
 				if !existing {
 					metrics.AddNATEntry()
 					go func() {
 						assocHandle(ctx, assoc)
-						metrics.RemoveNATEntry()
 						_ = assoc.Close()
+						nm.Del(clientAddrKey)
+						metrics.RemoveNATEntry()
 					}()
 				}
 			}
 			select {
 			case <-assoc.doneCh:
-				nm.Del(clientAddr.String())
+				nm.Del(clientAddrKey)
 				pkt.done()
 			default:
 				queued, closed := assoc.enqueue(pkt)
@@ -329,7 +331,7 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 					return
 				}
 				if closed {
-					nm.Del(clientAddr.String())
+					nm.Del(clientAddrKey)
 					pkt.done()
 					return
 				}

--- a/service/udp.go
+++ b/service/udp.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shadowsocks/go-shadowsocks2/socks"
 	"golang.getoutline.org/sdk/transport"
 	"golang.getoutline.org/sdk/transport/shadowsocks"
-	"github.com/shadowsocks/go-shadowsocks2/socks"
 
 	"golang.getoutline.org/tunnel-server/internal/slicepool"
 	onet "golang.getoutline.org/tunnel-server/net"
@@ -322,9 +322,19 @@ func PacketServe(clientConn net.PacketConn, assocHandle AssociationHandleFunc, m
 			select {
 			case <-assoc.doneCh:
 				nm.Del(clientAddr.String())
-			case assoc.readCh <- pkt:
+				pkt.done()
 			default:
+				queued, closed := assoc.enqueue(pkt)
+				if queued {
+					return
+				}
+				if closed {
+					nm.Del(clientAddr.String())
+					pkt.done()
+					return
+				}
 				slog.Debug("Dropping packet due to full read queue")
+				pkt.done()
 				// TODO: Add a metric to track number of dropped packets.
 			}
 		}()
@@ -350,6 +360,7 @@ type association struct {
 	readCh     chan *packet
 	doneCh     chan struct{}
 	closeOnce  sync.Once
+	mu         sync.Mutex
 }
 
 var _ net.Conn = (*association)(nil)
@@ -372,10 +383,40 @@ func (a *association) Write(b []byte) (n int, err error) {
 	return a.pc.WriteTo(b, a.clientAddr)
 }
 
+func (a *association) enqueue(pkt *packet) (queued bool, closed bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	select {
+	case <-a.doneCh:
+		return false, true
+	default:
+	}
+
+	select {
+	case a.readCh <- pkt:
+		return true, false
+	default:
+		return false, false
+	}
+}
+
 func (a *association) Close() error {
 	a.closeOnce.Do(func() {
 		if a.doneCh != nil {
 			close(a.doneCh)
+		}
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		for {
+			select {
+			case pkt := <-a.readCh:
+				if pkt != nil {
+					pkt.done()
+				}
+			default:
+				return
+			}
 		}
 	})
 	return nil

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 	"time"
 
-	"golang.getoutline.org/sdk/transport"
-	"golang.getoutline.org/sdk/transport/shadowsocks"
 	logging "github.com/op/go-logging"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.getoutline.org/sdk/transport"
+	"golang.getoutline.org/sdk/transport/shadowsocks"
 
 	onet "golang.getoutline.org/tunnel-server/net"
 )
@@ -221,6 +221,7 @@ func TestAssociationCloseWhileReading(t *testing.T) {
 		pc:         makePacketConn(),
 		clientAddr: &clientAddr,
 		readCh:     make(chan *packet),
+		doneCh:     make(chan struct{}),
 	}
 	go func() {
 		buf := make([]byte, 1024)
@@ -230,6 +231,37 @@ func TestAssociationCloseWhileReading(t *testing.T) {
 	err := assoc.Close()
 
 	assert.NoError(t, err, "Close should not panic or return an error")
+}
+
+func TestAssociationCloseReleasesQueuedPackets(t *testing.T) {
+	assoc := &association{
+		pc:         makePacketConn(),
+		clientAddr: &clientAddr,
+		readCh:     make(chan *packet, 2),
+		doneCh:     make(chan struct{}),
+	}
+	released := 0
+	assoc.readCh <- &packet{payload: []byte{1}, done: func() { released++ }}
+	assoc.readCh <- &packet{payload: []byte{2}, done: func() { released++ }}
+
+	err := assoc.Close()
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, released, "Close should release queued packets")
+}
+
+func TestAssociationEnqueueAfterClose(t *testing.T) {
+	assoc := &association{
+		pc:         makePacketConn(),
+		clientAddr: &clientAddr,
+		readCh:     make(chan *packet, 1),
+		doneCh:     make(chan struct{}),
+	}
+	require.NoError(t, assoc.Close())
+
+	queued, closed := assoc.enqueue(&packet{payload: []byte{1}, done: func() {}})
+	require.False(t, queued)
+	require.True(t, closed)
 }
 
 func TestAssociationHandler_Handle_IPFilter(t *testing.T) {

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -150,15 +150,23 @@ type udpReport struct {
 
 // Stub metrics implementation for testing NAT behaviors.
 type natTestMetrics struct {
-	natEntriesAdded int
+	natEntriesAdded   int
+	natEntriesRemoved int
+	mu                sync.Mutex
 }
 
 var _ NATMetrics = (*natTestMetrics)(nil)
 
 func (m *natTestMetrics) AddNATEntry() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.natEntriesAdded++
 }
-func (m *natTestMetrics) RemoveNATEntry() {}
+func (m *natTestMetrics) RemoveNATEntry() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.natEntriesRemoved++
+}
 
 type fakeUDPAssociationMetrics struct {
 	accessKey       string
@@ -262,6 +270,47 @@ func TestAssociationEnqueueAfterClose(t *testing.T) {
 	queued, closed := assoc.enqueue(&packet{payload: []byte{1}, done: func() {}})
 	require.False(t, queued)
 	require.True(t, closed)
+}
+
+func TestPacketServeRemovesClosedAssociationsFromNAT(t *testing.T) {
+	clientConn := makePacketConn()
+	metrics := &natTestMetrics{}
+	handled := make(chan []byte, 2)
+	done := make(chan struct{})
+
+	go func() {
+		PacketServe(clientConn, func(ctx context.Context, conn net.Conn) {
+			buf := make([]byte, 16)
+			n, err := conn.Read(buf)
+			if err != nil {
+				t.Errorf("Read failed: %v", err)
+				return
+			}
+			handled <- append([]byte(nil), buf[:n]...)
+		}, metrics)
+		close(done)
+	}()
+
+	clientConn.recv <- fakePacket{addr: &clientAddr, payload: []byte{1}}
+	require.Equal(t, []byte{1}, <-handled)
+
+	require.Eventually(t, func() bool {
+		metrics.mu.Lock()
+		defer metrics.mu.Unlock()
+		return metrics.natEntriesAdded == 1 && metrics.natEntriesRemoved == 1
+	}, time.Second, 10*time.Millisecond)
+
+	clientConn.recv <- fakePacket{addr: &clientAddr, payload: []byte{2}}
+	require.Equal(t, []byte{2}, <-handled)
+
+	require.Eventually(t, func() bool {
+		metrics.mu.Lock()
+		defer metrics.mu.Unlock()
+		return metrics.natEntriesAdded == 2 && metrics.natEntriesRemoved == 2
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, clientConn.Close())
+	<-done
 }
 
 func TestAssociationHandler_Handle_IPFilter(t *testing.T) {

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 	"time"
 
-	"golang.getoutline.org/sdk/transport"
-	"golang.getoutline.org/sdk/transport/shadowsocks"
 	logging "github.com/op/go-logging"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.getoutline.org/sdk/transport"
+	"golang.getoutline.org/sdk/transport/shadowsocks"
 
 	onet "golang.getoutline.org/tunnel-server/net"
 )
@@ -150,15 +150,23 @@ type udpReport struct {
 
 // Stub metrics implementation for testing NAT behaviors.
 type natTestMetrics struct {
-	natEntriesAdded int
+	natEntriesAdded   int
+	natEntriesRemoved int
+	mu                sync.Mutex
 }
 
 var _ NATMetrics = (*natTestMetrics)(nil)
 
 func (m *natTestMetrics) AddNATEntry() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.natEntriesAdded++
 }
-func (m *natTestMetrics) RemoveNATEntry() {}
+func (m *natTestMetrics) RemoveNATEntry() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.natEntriesRemoved++
+}
 
 type fakeUDPAssociationMetrics struct {
 	accessKey       string
@@ -221,6 +229,7 @@ func TestAssociationCloseWhileReading(t *testing.T) {
 		pc:         makePacketConn(),
 		clientAddr: &clientAddr,
 		readCh:     make(chan *packet),
+		doneCh:     make(chan struct{}),
 	}
 	go func() {
 		buf := make([]byte, 1024)
@@ -230,6 +239,78 @@ func TestAssociationCloseWhileReading(t *testing.T) {
 	err := assoc.Close()
 
 	assert.NoError(t, err, "Close should not panic or return an error")
+}
+
+func TestAssociationCloseReleasesQueuedPackets(t *testing.T) {
+	assoc := &association{
+		pc:         makePacketConn(),
+		clientAddr: &clientAddr,
+		readCh:     make(chan *packet, 2),
+		doneCh:     make(chan struct{}),
+	}
+	released := 0
+	assoc.readCh <- &packet{payload: []byte{1}, done: func() { released++ }}
+	assoc.readCh <- &packet{payload: []byte{2}, done: func() { released++ }}
+
+	err := assoc.Close()
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, released, "Close should release queued packets")
+}
+
+func TestAssociationEnqueueAfterClose(t *testing.T) {
+	assoc := &association{
+		pc:         makePacketConn(),
+		clientAddr: &clientAddr,
+		readCh:     make(chan *packet, 1),
+		doneCh:     make(chan struct{}),
+	}
+	require.NoError(t, assoc.Close())
+
+	queued, closed := assoc.enqueue(&packet{payload: []byte{1}, done: func() {}})
+	require.False(t, queued)
+	require.True(t, closed)
+}
+
+func TestPacketServeRemovesClosedAssociationsFromNAT(t *testing.T) {
+	clientConn := makePacketConn()
+	metrics := &natTestMetrics{}
+	handled := make(chan []byte, 2)
+	done := make(chan struct{})
+
+	go func() {
+		PacketServe(clientConn, func(ctx context.Context, conn net.Conn) {
+			buf := make([]byte, 16)
+			n, err := conn.Read(buf)
+			if err != nil {
+				t.Errorf("Read failed: %v", err)
+				return
+			}
+			handled <- append([]byte(nil), buf[:n]...)
+		}, metrics)
+		close(done)
+	}()
+
+	clientConn.recv <- fakePacket{addr: &clientAddr, payload: []byte{1}}
+	require.Equal(t, []byte{1}, <-handled)
+
+	require.Eventually(t, func() bool {
+		metrics.mu.Lock()
+		defer metrics.mu.Unlock()
+		return metrics.natEntriesAdded == 1 && metrics.natEntriesRemoved == 1
+	}, time.Second, 10*time.Millisecond)
+
+	clientConn.recv <- fakePacket{addr: &clientAddr, payload: []byte{2}}
+	require.Equal(t, []byte{2}, <-handled)
+
+	require.Eventually(t, func() bool {
+		metrics.mu.Lock()
+		defer metrics.mu.Unlock()
+		return metrics.natEntriesAdded == 2 && metrics.natEntriesRemoved == 2
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, clientConn.Close())
+	<-done
 }
 
 func TestAssociationHandler_Handle_IPFilter(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Recent fixes left a race where UDP packet buffers could be retained when associations closed or when per-association read queues were full, causing a memory leak. 

### Description
- Ensure `PacketServe` releases pooled buffers immediately when an association is already closed or when the per-association queue is full by invoking the packet `done()` callback instead of retaining the buffer in-place in `service/udp.go`.
- Add a synchronized enqueue path with `enqueue()` and a `mu` to avoid a race between `Close()` and new queueing, and make `Close()` drain `readCh` and call each queued packet’s `done()` to free resources.
- Add regression tests in `service/udp_test.go`: `TestAssociationCloseReleasesQueuedPackets` and `TestAssociationEnqueueAfterClose`, and ensure `TestAssociationCloseWhileReading` covers the read/close interaction.
- Minor import reordering and run `gofmt` on modified files.

### Testing
- Ran `gofmt -w` on `service/udp.go` and `service/udp_test.go` and verified `git diff --check` produced no issues.
- Attempted to run targeted tests with `go test ./service -run 'TestAssociation(CloseWhileReading|CloseReleasesQueuedPackets|EnqueueAfterClose)'`, but execution failed due to the environment being unable to download Go modules from `proxy.golang.org` / GitHub (HTTP 403), so tests could not be executed here.
- Attempted `go test ./...` but it similarly failed for the same module download restriction.
